### PR TITLE
Do not write sharedStrings.xml relationship unless @workbook.shared_strings is present

### DIFF
--- a/lib/rubyXL/writer/workbook_rels_writer.rb
+++ b/lib/rubyXL/writer/workbook_rels_writer.rb
@@ -42,10 +42,13 @@ module Writer
           xml.Relationship('Id'=>'rId'+i.to_s,
             'Type'=>"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
             'Target'=>'styles.xml')
-          i+=1
-          xml.Relationship('Id'=>'rId'+i.to_s,
+
+          unless @workbook.shared_strings.nil?
+            i+=1
+            xml.Relationship('Id'=>'rId'+i.to_s,
             'Type'=>"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings",
               'Target'=>'sharedStrings.xml')
+          end
         }
       end
       contents = builder.to_xml


### PR DESCRIPTION
Hi, 

The RubyXL gem writes the relationship for `sharedStrings.xml` regardless of whether `@workbook.shared_strings` is present. 

Based on the code, it seems that RubyXL only uses shared_strings if they are present at parsing, but not when writing a generated excel workbook. 

Based on saving and inspecting new empty excel files' XMLs, it seems that an empty sharedStrings.xml isn't necessary. 

This fixes the preview problem and allows the file to be opened by OpenXML Productivity Tool (previously unopenable due to the missing sharedStrings.xml). 

Hope it helps. 
