### PR TITLE
undefined method 'split' for 0:Fixnum

### DIFF
--- a/lib/rubyXL/workbook.rb
+++ b/lib/rubyXL/workbook.rb
@@ -252,7 +252,7 @@ module RubyXL
 
       state = 0
       s = ''
-      num_fmt.split(//).each do |c|
+      num_fmt.to_s.split(//).each do |c|
         if state == 0
           if c == '"'
             state = 1


### PR DESCRIPTION
workbook = RubyXL::Parser.parse('formatbug.xlsx')
workbook.worksheets[0].sheet_data[0][0].value #raises exception above
