### PR TITLE
Fixed an incorrect mkdir_p call with correct path before creating the zi...

### DIFF
--- a/lib/rubyXL/workbook.rb
+++ b/lib/rubyXL/workbook.rb
@@ -118,7 +118,7 @@ module RubyXL
       #zips package and renames it to xlsx.
       zippath = File.join(dirpath, filename + '.zip')
       File.unlink(zippath) if File.exists?(zippath)
-      FileUtils.mkdir_p(File.join(dirpath,zippath))
+      FileUtils.mkdir_p(dirpath)
       Zip::ZipFile.open(zippath, Zip::ZipFile::CREATE) do |zipfile|
         writer = Writer::ContentTypesWriter.new(dirpath,self)
         zipfile.get_output_stream('[Content_Types].xml') {|f| f.puts(writer.write())}


### PR DESCRIPTION
...p file. Normally on non-Windows platform, this does not cause trouble (just extra sub-directories created). But on Windows, since the path would contain drive like 'C:' which would failed the call to mkdir_p.
