### PR TITLE
Small Gemfile fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source "http://rubygems.org"
-# Add dependencies required to use your gem here.
-# Example:
-#   gem "activesupport", ">= 2.3.5"
 
-# Add dependencies to develop your gem here.
-# Include everything needed to run rake, tests, features, etc.
+# Dependencies required to run this gem.
+gem "nokogiri", ">= 1.4.4"
+gem "rubyzip", ">= 1.0.0"
+
+# Development dependencies.
 group :development do
   gem "shoulda", ">= 0"
   gem "bundler"
@@ -16,7 +16,5 @@ group :development do
   	gem "rcov", ">= 0"
   end
 
-  gem "nokogiri", ">= 1.4.4"
-  gem "rubyzip", ">= 1.0.0"
   gem "rspec", ">= 1.3.4"
 end


### PR DESCRIPTION
Hi. Nokogiri and rubyzip actually aren't just development dependencies, they are required to run rubyXL.
