### PR TITLE
Nokogiri unable to handle RubyZip's streams in JRuby

### DIFF
--- a/lib/rubyXL/objects/ooxml_object.rb
+++ b/lib/rubyXL/objects/ooxml_object.rb
@@ -436,7 +436,7 @@ module RubyXL
       when Zip::File then
         file_path = file_path.relative_path_from(::Pathname.new("/")) if file_path.absolute? # Zip doesn't like absolute paths.
         entry = dirpath.find_entry(file_path)
-        entry && (entry.get_input_stream { |f| parse(f) })
+        entry && (entry.get_input_stream { |f| parse(f.read) })
       end
     end
 


### PR DESCRIPTION
it looks like a .read is missing here, since in JRuby the "f" is still a Zip::InputStream.
Inside Nokogiri a the following exception is raised "Uncaught exception: must be kind_of String or respond to :to_io or :string", if the .read is missing.
With this change it works in MRI (tested with 2.1.2) and JRuby (tested with 1.7.13)
