### PR TITLE
Added convenience method for number of rows in a worksheet

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,9 +17,10 @@
 === Accessing
 
 ==== Accessing a Worksheet
-  workbook.worksheets[0] # Returns first worksheet
-  workbook[0]            # Returns first worksheet
-  workbook['Sheet1']     # Finds and returns worksheet titled "Sheet1"
+  workbook.worksheets[0]      # Returns first worksheet
+  workbook[0]                 # Returns first worksheet
+  workbook['Sheet1']          # Finds and returns worksheet titled "Sheet1"
+  workbook.worksheets[0].size # Returns the number of rows in a worksheet
 
 ==== Accessing just the values
   worksheet = workbook[0]

--- a/lib/rubyXL/worksheet.rb
+++ b/lib/rubyXL/worksheet.rb
@@ -23,6 +23,10 @@ module LegacyWorksheet
     sheet_data.rows.each { |row| yield(row) }
   end
 
+  def size
+    sheet_data.size
+  end
+
   #returns 2d array of just the cell values (without style or formula information)
   def extract_data(args = {})
     sheet_data.rows.map { |row|

--- a/spec/lib/worksheet_spec.rb
+++ b/spec/lib/worksheet_spec.rb
@@ -17,6 +17,13 @@ describe RubyXL::Worksheet do
     @old_cell_formula = @worksheet[0][0].formula
   end
 
+  describe '.size' do
+    it 'should return the number of rows in the worksheet' do
+      data = @worksheet.extract_data()
+      expect(data.size).to eq(@worksheet.size)
+    end
+  end
+
   describe '.extract_data' do
     it 'should return a 2d array of just the cell values (without style or formula information)' do
       data = @worksheet.extract_data()


### PR DESCRIPTION
Instead of digging through the code to find out how to get the number of
row in a worksheet I added a convenience method. I updated the docs so
its easy to find.
