### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,7 +74,7 @@ Please note: these methods are being phased out in favor of the OOXML object mod
   worksheet.get_column_font_size(0)
   worksheet.get_column_font_color(0)
   worksheet.is_column_underlined(0)
-  worksheet.get_column_height(0)
+  worksheet.get_column_width(0)
   worksheet.get_column_horizontal_alignment(0)
   worksheet.get_column_vertical_alignment(0)
   worksheet.get_column_border_right(0)


### PR DESCRIPTION
Typo: Fixed get_column_height into get_column_width. The first doesn't exist for worksheet and will return and error.
