### PR TITLE
Unescape escaped unicode characters

### DIFF
--- a/lib/rubyXL/objects/text.rb
+++ b/lib/rubyXL/objects/text.rb
@@ -11,13 +11,15 @@ module RubyXL
     define_attribute(:'xml:space', :string)
     define_element_name 't'
 
+    ESCAPED_UNICODE = /_x([0-9A-F]{4})_/
+
     def before_write_xml
       self.xml_space = (value.is_a?(String) && ((value =~ /\A\s/) || (value =~ /\s\Z/) || value.include?("\n"))) ? 'preserve' : nil
       true
     end
 
     def to_s
-      value.to_s
+      value.to_s.gsub(ESCAPED_UNICODE) { |m| "0x#{$1}".hex.chr }
     end
   end
 


### PR DESCRIPTION
Excel for Windows escapes `\r` into `_x000D_` because it is not permitted in an XML 1.0 document.

I did this fix in `RubyXL::Text`, but other class like `ST_Xstring` is more appropriate, I think.
If this is not good, please tell me it.

> _22.9.2.19 ST_Xstring (Escaped String) String of characters with
> support for escaped invalid-XML characters. For all characters which
> cannot be represented in XML as defined by the XML 1.0 specification,
> the characters are escaped using the Unicode numerical character
> representation escape character format _xHHHH_,  where H represents a
> hexadecimal character in the character's value. [Example: The Unicode
> character 8 is not permitted in an XML 1.0 document,  so it must be
> escaped as _x0008_. end example]_
