### PR TITLE
fix date parsing off-by-one on days pre march 1st 1900

### DIFF
--- a/lib/rubyXL/objects/workbook.rb
+++ b/lib/rubyXL/objects/workbook.rb
@@ -393,6 +393,7 @@ module RubyXL
     DATE1904 = DateTime.new(1904, 1, 1)
     # Subtracting one day to accomodate for erroneous 1900 leap year compatibility only for 1900 based dates
     DATE1899 = DateTime.new(1899, 12, 31) - 1
+    DATE1900MARCH1 = 61
 
     def base_date
       (workbook_properties && workbook_properties.date1904) ? DATE1904 : DATE1899
@@ -404,7 +405,9 @@ module RubyXL
     end
 
     def num_to_date(num)
-      num && (base_date + num)
+      # unsubtract that one day if the date is before March 1st
+      leap_fix = (base_date == DATE1899 && num < DATE1900MARCH1) ? 1 : 0
+      num && (base_date + num + leap_fix)
     end
 
     include Enumerable

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -180,6 +180,12 @@ describe RubyXL::Cell do
         expect(@cell.value).to eq(Date.parse('April 20, 2012'))
         @cell.change_contents(35981)
         expect(@cell.value).to eq(Date.parse('July 5, 1998'))
+        @cell.change_contents(59)
+        expect(@cell.value).to eq(Date.parse('February 28, 1900'))
+        @cell.change_contents(60)
+        expect(@cell.value).to eq(Date.parse('March 1, 1900')) # 29th doesn't exists, will be parsed as march 1st
+        @cell.change_contents(61)
+        expect(@cell.value).to eq(Date.parse('March 1, 1900'))
       end
     end
     context '1904-based dates' do


### PR DESCRIPTION
The existing 1900 leap year bug fix introduced a off-by-one bug on dates between Jan 1st 1900 and March 1st 1900. This resolves that