### PR TITLE
Make the cell’s datatype nil when setting a BigDecimal.

### DIFF
--- a/lib/rubyXL/cell.rb
+++ b/lib/rubyXL/cell.rb
@@ -104,7 +104,7 @@ module RubyXL
         self.formula = RubyXL::Formula.new(:expression => formula_expression)
       else
         self.datatype = case data
-                        when Date, Integer, Float then nil
+                        when Date, Numeric then nil
                         else RubyXL::DataType::RAW_STRING
                         end
       end

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -232,6 +232,14 @@ describe RubyXL::Cell do
       expect(@cell.formula).to be_nil
     end
 
+    it 'should case cell value to match a numeric that is passed in' do
+      number = 1.25
+      @cell.change_contents(number)
+      expect(@cell.value).to eq(number)
+      expect(@cell.datatype).to be_nil
+      expect(@cell.formula).to be_nil
+    end
+
     it 'should cause cell value and formula to match what is passed in' do
       @cell.change_contents(nil, 'SUM(A2:A4)')
       expect(@cell.value).to be_nil


### PR DESCRIPTION
This will mean that BigDecimal objects are treated the same as other numeric objects.