### PR TITLE
Fix the wrong element naming from a:cxn to a:path

### DIFF
--- a/lib/rubyXL/objects/theme.rb
+++ b/lib/rubyXL/objects/theme.rb
@@ -1016,7 +1016,7 @@ module RubyXL
     define_attribute(:fill,        RubyXL::ST_PathFillMode, :default => 'norm')
     define_attribute(:stroke,      :bool, :default => true)
     define_attribute(:extrusionOk, :bool, :default => true)
-    define_element_name 'a:cxn'
+    define_element_name 'a:path'
   end
 
   # http://www.schemacentral.com/sc/ooxml/e-a_pathLst-1.html


### PR DESCRIPTION
For one of my excel file I have been receiving the following error
```
Unknown child node [a:path] for element [pathLst]
```
As per schemacentral.com link http://www.schemacentral.com/sc/ooxml/e-a_path-2.html , the element name should be `a:path` instead `a:cxn`. This PR fixes the issue.