### PR TITLE
pass through cell contents that cause encoding errors, #195

### DIFF
--- a/lib/rubyXL/objects/text.rb
+++ b/lib/rubyXL/objects/text.rb
@@ -25,6 +25,8 @@ module RubyXL
 
     def to_s
       value.to_s.gsub(ESCAPED_UNICODE) { |m| $1.hex.chr }
+    rescue Encoding::CompatibilityError
+      value.to_s
     end
   end
 


### PR DESCRIPTION
Quick fix for https://github.com/weshatheleopard/rubyXL/issues/195

There is probably a way to handle this case, but it might require a special case in the parser.