### PR TITLE
Fix border example

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -47,7 +47,7 @@ Please note that proprietary binary +xls+ format is *not* supported.
   cell.fill_color
   cell.horizontal_alignment
   cell.vertical_alignment
-  cell.border_top
+  cell.get_border(:top)
 
 ==== Wrappers for accessing Row properties 
 Please note: these methods are being phased out in favor of the OOXML object model.


### PR DESCRIPTION
Hello I'm newbie rubyXL.

Fix following error in readme.rdoc.

```
cell.border_top
NoMethodError: undefined method `border_top' for #<RubyXL::Cell(0,0): nil, datatype=nil, style_index=2>
```
