### PR TITLE
Add get_row_height_raw method

### DIFF
--- a/lib/rubyXL/convenience_methods.rb
+++ b/lib/rubyXL/convenience_methods.rb
@@ -377,11 +377,17 @@ module RubyXL
       (font = row_font(row)) && font.is_strikethrough
     end
 
-    def get_row_height(row = 0)
+    def get_row_height_raw(row = 0)
       validate_workbook
       validate_nonnegative(row)
       row = sheet_data.rows[row]
-      row && row.ht || RubyXL::Row::DEFAULT_HEIGHT
+      return nil if row.nil?
+      row.ht
+    end
+
+    def get_row_height(row = 0)
+      ht = get_row_height_raw(row)
+      ht || RubyXL::Row::DEFAULT_HEIGHT
     end
 
     def get_row_border(row, border_direction)


### PR DESCRIPTION
I would like to get nil value if the cell does not have height property. 
I found [``get_column_width_raw``](https://github.com/weshatheleopard/rubyXL/blob/master/lib/rubyXL/convenience_methods.rb#L460-L467) method. 
This is similar method for height. 