### PR TITLE
2016315 create numbers compatible xlsx

### DIFF
--- a/lib/rubyXL/objects/workbook.rb
+++ b/lib/rubyXL/objects/workbook.rb
@@ -313,7 +313,9 @@ module RubyXL
     end
 
     def related_objects
-      [ calculation_chain, stylesheet, theme, shared_strings_container, macros ] + @worksheets
+      objects = [ calculation_chain, stylesheet, theme, macros ]
+      objects += shared_strings_container unless shared_strings_container.strings.empty?
+      objects + @worksheets
     end
 
     define_relationship(RubyXL::SharedStringsTable, :shared_strings_container)

--- a/spec/lib/workbook_spec.rb
+++ b/spec/lib/workbook_spec.rb
@@ -154,7 +154,7 @@ describe RubyXL::Workbook do
   end
 
   describe '#related_objects' do
-    it 'should ot include shared string when not present' do
+    it 'should not include shared string when not present' do
       workbook = RubyXL::Workbook.new
       expect(workbook.related_objects.map{|obj|obj.class.name}).not_to include('RubyXL::SharedStringsTable')
     end

--- a/spec/lib/workbook_spec.rb
+++ b/spec/lib/workbook_spec.rb
@@ -153,4 +153,10 @@ describe RubyXL::Workbook do
     end
   end
 
+  describe '#related_objects' do
+    it 'should ot include shared string when not present' do
+      workbook = RubyXL::Workbook.new
+      expect(workbook.related_objects.map{|obj|obj.class.name}).not_to include('RubyXL::SharedStringsTable')
+    end
+  end
 end


### PR DESCRIPTION
Not to include shared string as related objects when there is no shared strings. This resolves the same issue described in https://github.com/weshatheleopard/rubyXL/issues/158  (Numbers in iOS can't open rubyXL generated xlsx file)