### PR TITLE
exclude empty related objects from writing xml

### DIFF
--- a/lib/rubyXL/objects/relationships.rb
+++ b/lib/rubyXL/objects/relationships.rb
@@ -118,7 +118,7 @@ module RubyXL
         related_objects += owner.generic_storage if owner.generic_storage
 
         self.relationships = []
-        related_objects.compact.each { |f| add_relationship(f) }
+        related_objects.compact.each { |f| add_relationship(f) unless f.respond_to?(:empty?) && f.empty? } 
       end
       super
     end

--- a/spec/lib/workbook_spec.rb
+++ b/spec/lib/workbook_spec.rb
@@ -161,6 +161,16 @@ describe RubyXL::Workbook do
       wb.shared_strings_container.add('test')
       expect(wb.root.collect_related_objects.map{ |x| x.class }.include?(::RubyXL::SharedStringsTable)).to be true
     end
+
+    it 'should not include empty shared strings in relationship_container' do
+      wb = RubyXL::Workbook.new
+      wb.root.stream
+      expect(wb.relationship_container.relationships.map{ |x| x.target.to_s }.include?('sharedStrings.xml')).to be false
+
+      wb.shared_strings_container.add('test')
+      wb.root.stream
+      expect(wb.relationship_container.relationships.map{ |x| x.target.to_s }.include?('sharedStrings.xml')).to be true
+    end
   end
 
 end


### PR DESCRIPTION
https://github.com/weshatheleopard/rubyXL/commit/82573bfe2d36ba04f76b958eab96c3b5404ee8e9
The above commit does not exclude empty shared strings from being written to xml. Numbers on iOS still has problem opening the generated file. This seems to have solved the problem, please review.