### PR TITLE
Add methods to allow changing the border color of cells

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -52,6 +52,7 @@ Please note that row is a _sparse_ array of cells. Your code *must* expect that 
   cell.horizontal_alignment
   cell.vertical_alignment
   cell.get_border(:top)
+  cell.get_border_color(:top)
 
 ==== Wrappers for accessing Row properties 
 Please note: these methods are being phased out in favor of the OOXML object model.
@@ -65,6 +66,7 @@ Please note: these methods are being phased out in favor of the OOXML object mod
   worksheet.get_row_alignment(0, true)
   worksheet.get_row_alignment(0, false)
   worksheet.get_row_border(0, :right)
+  worksheet.get_row_border_color(0, :right)
 
 ==== Accessing column properties
 Please note: these methods are being phased out in favor of the OOXML object model.
@@ -78,6 +80,7 @@ Please note: these methods are being phased out in favor of the OOXML object mod
   worksheet.get_column_alignment(0, :horizontal)
   worksheet.get_column_alignment(0, :vertical)
   worksheet.get_column_border(0, :right)
+  worksheet.get_column_border_color(0, :right)
 
 ==== Table reading
 In order to discourage unnecessary reshuffling of data in memory, methods +extract_data+ and +get_table+ are being deprecated. You should access and iterate through rows and cells directly:
@@ -120,6 +123,10 @@ In order to discourage unnecessary reshuffling of data in memory, methods +extra
   worksheet.sheet_data[0][0].change_border(:top, 'thin')  # Sets A1 to have a top, thin border
   worksheet.change_row_border(0, :left, 'hairline')       # Sets first row to have a left, hairline border
   worksheet.change_column_border(0, :diagonal, 'medium')  # Sets first column to have diagonal, medium border
+
+  # Set the border style first so there's something to color.
+  worksheet.change_row_border_color(0, :top, '0ba53d')    # Sets first row to have a green top border
+  worksheet.change_column_border_color(0, :top, '0ba53d') # Sets first column to have a green top border
 
 ==== Changing Alignment
 ===== Horizontal

--- a/lib/rubyXL/objects/border.rb
+++ b/lib/rubyXL/objects/border.rb
@@ -6,6 +6,14 @@ module RubyXL
   class BorderEdge < OOXMLObject
     define_attribute(:style, RubyXL::ST_BorderStyle, :default => 'none')
     define_child_node(RubyXL::Color)
+
+    def set_rgb_color(font_color)
+      self.color = RubyXL::Color.new(:rgb => font_color.to_s)
+    end
+
+    def get_rgb_color
+      color && color.rgb
+    end
   end
 
   # http://www.schemacentral.com/sc/ooxml/e-ssml_border-2.html
@@ -28,7 +36,27 @@ module RubyXL
     end
 
     def set_edge_style(direction, style)
-      self.send("#{direction}=", RubyXL::BorderEdge.new(:style => style))
+      edge = self.send(direction)
+      if edge
+        edge.style = style
+      else
+        self.send("#{direction}=", RubyXL::BorderEdge.new(:style => style))
+      end
+    end
+
+    def get_edge_color(direction)
+      edge = self.send(direction)
+      edge && edge.get_rgb_color
+    end
+
+    def set_edge_color(direction, color)
+      edge = self.send(direction)
+      if edge
+        edge.set_rgb_color(color)
+      else
+        self.send("#{direction}=", RubyXL::BorderEdge.new)
+        self.send(direction).set_rgb_color(color)
+      end
     end
   end
 

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -143,6 +143,47 @@ describe RubyXL::Cell do
     end
   end
 
+  describe '.change_border_color' do
+    it 'should cause cell to have a colored top border' do
+      expect(@cell.get_border_color(:top)).to be_nil
+      @cell.change_border_color(:top, 'FF0000')
+      expect(@cell.get_border_color(:top)).to eq('FF0000')
+    end
+
+    it 'should cause cell to have a colored bottom border' do
+      expect(@cell.get_border_color(:bottom)).to be_nil
+      @cell.change_border_color(:bottom, 'FF0000')
+      expect(@cell.get_border_color(:bottom)).to eq('FF0000')
+    end
+
+    it 'should cause cell to have a colored left border' do
+      expect(@cell.get_border_color(:left)).to be_nil
+      @cell.change_border_color(:left, 'FF0000')
+      expect(@cell.get_border_color(:left)).to eq('FF0000')
+    end
+
+    it 'should cause cell to have a colored right border' do
+      expect(@cell.get_border_color(:right)).to be_nil
+      @cell.change_border_color(:right, 'FF0000')
+      expect(@cell.get_border_color(:right)).to eq('FF0000')
+    end
+
+    it 'should cause cell to have a colored diagonal border' do
+      expect(@cell.get_border_color(:diagonal)).to be_nil
+      @cell.change_border_color(:diagonal, 'FF0000')
+      expect(@cell.get_border_color(:diagonal)).to eq('FF0000')
+    end
+
+    it 'is not overridden if the border style is set afterwards' do
+      expect(@cell.get_border_color(:top)).to be_nil
+      expect(@cell.get_border(:top)).to be_nil
+      @cell.change_border_color(:top, 'FF0000')
+      @cell.change_border(:top, 'thin')
+      expect(@cell.get_border_color(:top)).to eq('FF0000')
+      expect(@cell.get_border(:top)).to eq('thin')
+    end
+  end
+
   describe '.change_border' do
     it 'should cause cell to have border at top with specified weight' do
       expect(@cell.get_border(:top)).to be_nil


### PR DESCRIPTION
This PR lets people change the color of cell borders. I added convenience methods for coloring column/row borders, explained them in the README, and added specs.

Here's how you can sample it:

```ruby
row_index = 0
[:top, :bottom, :left, :right].each do |dir|
  # sheet is a worksheet object
  sheet.change_row_border(row_index, dir, 'thin')
  sheet.change_row_border_color(row_index, dir, 'ff0000')
end
```

That should give the first row in a spreadsheet a bright red border.

Let me know if you have any questions or suggestions for how to improve this. Thanks!