### PR TITLE
Fix bug in `modify_border` to show border of cell

### DIFF
--- a/lib/rubyXL/convenience_methods.rb
+++ b/lib/rubyXL/convenience_methods.rb
@@ -168,6 +168,10 @@ module RubyXL
     def modify_border(style_index, direction, weight)
       xf = cell_xfs[style_index || 0].dup
       new_border = borders[xf.border_id || 0].dup
+
+      edge = new_border.send(direction)
+      new_border.send("#{direction}=", edge.dup) if edge
+
       new_border.set_edge_style(direction, weight)
 
       xf.border_id = borders.find_index { |x| x == new_border } # Reuse existing border, if it exists


### PR DESCRIPTION
It seems like invoking `change_border` doesn't apply a border cell style to generated excel after `2817018d57fd0ccb5a1c4d52b75950ba71671fac` was committed.

This PR fixed it but I'm not sure how to test it accurately.

Thanks!