### PR TITLE
Fix for date cells with a very short time after 1899-12-31

### DIFF
--- a/lib/rubyXL/objects/sheet_data.rb
+++ b/lib/rubyXL/objects/sheet_data.rb
@@ -66,7 +66,12 @@ module RubyXL
     end
 
     def is_date?
-      return false unless raw_value =~ /\A\d+(?:\.\d+)?\Z/ # Only fully numeric values can be dates
+      begin
+        # Only fully numeric values can be dates
+        Float(raw_value)
+      rescue
+        return false
+      end
       num_fmt = self.number_format
       num_fmt && num_fmt.is_date_format?
     end

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -275,6 +275,8 @@ describe RubyXL::Cell do
         expect(@cell.value).to eq(Date.parse('April 20, 2012'))
         @cell.change_contents(35981)
         expect(@cell.value).to eq(Date.parse('July 5, 1998'))
+        @cell.change_contents(0.019467592592592595)
+        expect(@cell.value).to eq(DateTime.parse('1899-12-31T00:28:02+00:00'))
         @cell.change_contents(1)
         expect(@cell.value).to eq(Date.parse('January 1, 1900'))
         @cell.change_contents(59)
@@ -284,6 +286,20 @@ describe RubyXL::Cell do
         expect(@cell.value).to eq(Date.parse('March 1, 1900'))
         @cell.change_contents(61)
         expect(@cell.value).to eq(Date.parse('March 1, 1900'))
+      end
+
+      context 'date before January 1, 1900' do
+        it 'should parse as date' do
+          @cell.set_number_format('h:mm:ss')
+          @cell.datatype = nil
+
+          @cell.raw_value = '0.97726851851851848'
+          expect(@cell.is_date?).to be(true)
+          expect(@cell.value).to eq(DateTime.parse('1899-12-31 23:27:16'))
+          @cell.raw_value = '1.9467592592592595E-2'
+          expect(@cell.is_date?).to be(true)
+          expect(@cell.value).to eq(DateTime.parse('1899-12-31 00:28:02'))
+        end
       end
     end
 


### PR DESCRIPTION
This may occur when a user formats a cell for time display only (h:mm:ss) and does not set the date.

In such case, it will not return the date as expected because  regexp does not allow raw value with a scientific notation number.