### PR TITLE
Improve performance of add_cell by fixing workbook validation (10-40x improvement)

### DIFF
--- a/lib/rubyXL/worksheet.rb
+++ b/lib/rubyXL/worksheet.rb
@@ -59,7 +59,7 @@ module LegacyWorksheet
   #validates Workbook, ensures that this worksheet is in @workbook
   def validate_workbook()
     unless @workbook.nil? || @workbook.worksheets.nil?
-      return if @workbook.worksheets.include?(self)
+      return if @workbook.worksheets.any? { |sheet| sheet.equal?(self) }
     end
 
     raise "This worksheet #{self} is not in workbook #{@workbook}"
@@ -72,7 +72,7 @@ module LegacyWorksheet
     validate_nonnegative(column_index)
 
     sheet_data.rows[row_index] || add_row(row_index)
-  end  
+  end
 
   def get_col_xf(column_index)
     @workbook.cell_xfs[get_col_style(column_index)]


### PR DESCRIPTION
This patch fixes a major performance issue with Worksheet. Every time a new column is added, rubyXL checks if the worksheet is included in the workbook. Unfortunately, it uses `include?` (which ultimately calls `==`) method, which compares every column of every row to see if the worksheets are the same.

This patch fixed this issue by comparing worksheets by reference, which improved performance significantly.

From Ruby documentation:

> Unlike ==, the equal? method should never be overridden by subclasses as it is used to determine object identity (that is, a.equal?(b) if and only if a is the same object as b):

Test used:

```ruby
val = 'a' * 50
workbook = RubyXL::Workbook.new
(1..5).each do |sheet|
  worksheet = workbook["Sheet#{sheet}"] || workbook.add_worksheet("Sheet#{sheet}")

  (1..1000).each do |row|
    (1..30).each do |col|
      worksheet.add_cell(row, col, val)
    end
  end
end
```

Benchmarking results:

```
Before: 75.90 real    72.16 user    0.54 sys
 After:  2.53 real     2.35 user    0.09 sys
```
