### PR TITLE
Merkle tree for style reusability

### DIFF
--- a/lib/rubyXL/objects/ooxml_object.rb
+++ b/lib/rubyXL/objects/ooxml_object.rb
@@ -18,6 +18,70 @@ module RubyXL
       self.class_variable_set(var_name, default)
     end
 
+    # This is like attr_accessor method, creating the getter and setter
+    # However, in this case the setter update the hash of the object containing it.
+    # It also trigger the parent in case of change
+    def hash_attr_accessor symbol
+      class_eval <<-RUBY, __FILE__, __LINE__
+        def #{symbol}
+          @#{symbol}
+        end
+
+        def #{symbol}= value
+          str_hash = "#{symbol}".hash
+
+          before_hash = @hash
+          @hash ^= @#{symbol}.hash ^ str_hash # Outmerge the hash component
+          @#{symbol} = value
+          @hash ^= @#{symbol}.hash ^ str_hash # Merge again the new hash component
+
+          if @parent
+            @parent.force_update_hash @parent_attribute, before_hash, @hash
+          end
+
+          value
+        end
+      RUBY
+    end
+
+    # This is like attr_accessor method, creating the getter and setter
+    # However, in this case the setter update the hash of the object containing it.
+    # It also register the parent link on setup
+    def hash_attr_accessor_child_node symbol
+      class_eval <<-RUBY, __FILE__, __LINE__
+        def #{symbol}
+          @#{symbol}
+        end
+
+        def #{symbol}= value
+          str_hash = "#{symbol}".hash
+
+          old_value = @#{symbol}
+
+          if old_value && old_value.is_a?(OOXMLObjectInstanceMethods)
+            old_value.parent = nil
+            old_value.parent_attribute = nil
+          end
+
+          if value && value.is_a?(OOXMLObjectInstanceMethods)
+            value.parent = self
+            value.parent_attribute = "#{symbol}"
+          end
+
+          before_hash = @hash
+          @hash ^= @#{symbol}.hash ^ str_hash # Outmerge the hash component
+          @#{symbol} = value
+          @hash ^= @#{symbol}.hash ^ str_hash # Merge again the new hash component
+
+          if @parent
+            @parent.force_update_hash @parent_attribute, before_hash, @hash
+          end
+
+          value
+        end
+      RUBY
+    end
+
     # Defines an attribute of OOXML object.
     # === Parameters
     # * +attribute_name+ - Name of the element attribute as seen in the source XML. Can be either <tt>"String"</tt> or <tt>:Symbol</tt>
@@ -50,7 +114,7 @@ module RubyXL
       attr_hash = extra_params.merge({ :attr_type => attr_type })
       attr_hash[:accessor] ||= accessorize(attr_name)
       attrs[attr_name.to_s] = attr_hash
-      self.send(:attr_accessor, attr_hash[:accessor]) unless attr_hash[:computed]
+      self.send(:hash_attr_accessor, attr_hash[:accessor]) unless attr_hash[:computed]
     end
 
     # Defines a child node of OOXML object.
@@ -86,7 +150,7 @@ module RubyXL
 
       define_count_attribute if extra_params[:collection] == :with_count
 
-      self.send(:attr_accessor, accessor)
+      self.send(:hash_attr_accessor_child_node, accessor)
     end
 
     def define_count_attribute
@@ -208,6 +272,12 @@ module RubyXL
   module OOXMLObjectInstanceMethods
     attr_accessor :local_namespaces
 
+    # Accessor used to get back to the parent from this node,
+    # and notify in case of hashing update
+    # Parent attribute show on which attribute the node is connected.
+    # In case of container parent (array like), parent_attribute remain "nil"
+    attr_accessor :parent, :parent_attribute
+
     def self.included(klass)
       klass.extend RubyXL::OOXMLObjectClassMethods
     end
@@ -225,6 +295,7 @@ module RubyXL
       }
 
       init_child_nodes(params)
+      recompute_hash
     end
 
     def init_child_nodes(params)
@@ -246,10 +317,25 @@ module RubyXL
     end
     private :preserve_whitespace
 
+    # Manually update a hashing part.
+    def force_update_hash attribute, before_hash, after_hash
+      @hash ^= before_hash ^ attribute.hash # Outmerge the hash component
+      @hash ^= after_hash ^ attribute.hash # Merge back the hash component
+    end
+
+    # Recompute the hash with segment given by the childrens
+    def recompute_hash
+      @hash = 0
+      @hash = obtain_class_variable(:@@ooxml_attributes).inject(@hash) { |h, (k, v)| h ^ k.hash ^ self.send(v[:accessor]).hash }
+      @hash = obtain_class_variable(:@@ooxml_child_nodes).inject(@hash) { |h, (k, v)| h ^ k.hash ^ self.send(v[:accessor]).hash }
+    end
+
+    def hash
+      @hash
+    end
+
     def ==(other)
-      other.is_a?(self.class) &&
-        obtain_class_variable(:@@ooxml_attributes).all? { |k, v| self.send(v[:accessor]) == other.send(v[:accessor]) } &&
-        obtain_class_variable(:@@ooxml_child_nodes).all? { |k, v| self.send(v[:accessor]) == other.send(v[:accessor]) }
+      self.hash == other.hash && other.is_a?(self.class)
     end
 
     # Recursively write the OOXML object and all its children out as Nokogiri::XML. Immediately before the actual


### PR DESCRIPTION
Related to #267 

Improve performance using Merkle tree on XML node for equality comparison instead of per-field equality.

This can improve **hugely** the rendering of an excel with a lot of differents styles (fonts, border etc...), by 2 or 3 magnitudes on my production's company reports.