### PR TITLE
Merged cell borders

### DIFF
--- a/lib/rubyXL/convenience_methods.rb
+++ b/lib/rubyXL/convenience_methods.rb
@@ -858,7 +858,20 @@ module RubyXL
 
     def change_border(direction, weight)
       validate_worksheet
-      self.style_index = workbook.modify_border(self.style_index, direction, weight)
+      merged_cell = worksheet.merged_cells && worksheet.merged_cells.detect { |mc| mc.cover?(row, column) }
+      cells = []
+      if merged_cell
+        merged_cell.ref.row_range.each do |r|
+          merged_cell.ref.col_range.each do |c|
+            cells << worksheet.add_cell(r, c, '', nil, false)
+          end
+        end
+      else
+        cells << self
+      end
+      cells.each do |cell|
+        cell.style_index = workbook.modify_border(cell.style_index, direction, weight)
+      end
     end
 
     def change_border_color(direction, color)

--- a/lib/rubyXL/objects/worksheet.rb
+++ b/lib/rubyXL/objects/worksheet.rb
@@ -100,6 +100,9 @@ module RubyXL
   class MergedCell < OOXMLObject
     define_attribute(:ref, :ref)
     define_element_name 'mergeCell'
+    def cover?(r,c)
+      ref.row_range.cover?(r) && ref.col_range.cover?(c)
+    end
   end
 
   # http://www.datypic.com/sc/ooxml/e-ssml_mergeCells-1.html

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -182,6 +182,104 @@ describe RubyXL::Cell do
       expect(@cell.get_border_color(:top)).to eq('FF0000')
       expect(@cell.get_border(:top)).to eq('thin')
     end
+
+    context "when the cell is merged horizontally" do
+      before :each do
+        @worksheet.merge_cells(0, 0, 0, 1)
+      end
+
+      it "should change the left border color of both merged cells" do
+        @cell.change_border_color(:left, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:left)).to eq("FF0000")
+        expect(@worksheet[0][1].get_border_color(:left)).to eq("FF0000")
+      end
+
+      it "should change the right border color of the both merged cells" do
+        @cell.change_border_color(:right, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:right)).to eq("FF0000")
+        expect(@worksheet[0][1].get_border_color(:right)).to eq("FF0000")
+      end
+
+      it "should change the top border color for both merged cells" do
+        @cell.change_border_color(:top, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:top)).to eq("FF0000")
+        expect(@worksheet[0][1].get_border_color(:top)).to eq("FF0000")
+      end
+
+      it "should change the bottom border color for both merged cells" do
+        @cell.change_border_color(:bottom, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:bottom)).to eq("FF0000")
+        expect(@worksheet[0][1].get_border_color(:bottom)).to eq("FF0000")
+      end
+    end
+
+    context "when the cell is merged vertically" do
+      before :each do
+        @worksheet.merge_cells(0, 0, 1, 0)
+      end
+
+      it "should change the left border color of both merged cells" do
+        @cell.change_border_color(:left, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:left)).to eq("FF0000")
+        expect(@worksheet[1][0].get_border_color(:left)).to eq("FF0000")
+      end
+
+      it "should change the right border color of the both merged cells" do
+        @cell.change_border_color(:right, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:right)).to eq("FF0000")
+        expect(@worksheet[1][0].get_border_color(:right)).to eq("FF0000")
+      end
+
+      it "should change the top border color for both merged cells" do
+        @cell.change_border_color(:top, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:top)).to eq("FF0000")
+        expect(@worksheet[1][0].get_border_color(:top)).to eq("FF0000")
+      end
+
+      it "should change the bottom border color for both merged cells" do
+        @cell.change_border_color(:bottom, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:bottom)).to eq("FF0000")
+        expect(@worksheet[1][0].get_border_color(:bottom)).to eq("FF0000")
+      end
+    end
+
+    context "when the cell is merged horizontally and veritically" do
+      before :each do
+        @worksheet.merge_cells(0, 0, 1, 1)
+      end
+
+      it "should change the left border color of both merged cells" do
+        @cell.change_border_color(:left, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:left)).to eq("FF0000")
+        expect(@worksheet[0][1].get_border_color(:left)).to eq("FF0000")
+        expect(@worksheet[1][0].get_border_color(:left)).to eq("FF0000")
+        expect(@worksheet[1][1].get_border_color(:left)).to eq("FF0000")
+      end
+
+      it "should change the right border color of the both merged cells" do
+        @cell.change_border_color(:right, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:right)).to eq("FF0000")
+        expect(@worksheet[0][1].get_border_color(:right)).to eq("FF0000")
+        expect(@worksheet[1][0].get_border_color(:right)).to eq("FF0000")
+        expect(@worksheet[1][1].get_border_color(:right)).to eq("FF0000")
+      end
+
+      it "should change the top border color for both merged cells" do
+        @cell.change_border_color(:top, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:top)).to eq("FF0000")
+        expect(@worksheet[0][1].get_border_color(:top)).to eq("FF0000")
+        expect(@worksheet[1][0].get_border_color(:top)).to eq("FF0000")
+        expect(@worksheet[1][1].get_border_color(:top)).to eq("FF0000")
+      end
+
+      it "should change the bottom border color for both merged cells" do
+        @cell.change_border_color(:bottom, "FF0000")
+        expect(@worksheet[0][0].get_border_color(:bottom)).to eq("FF0000")
+        expect(@worksheet[0][1].get_border_color(:bottom)).to eq("FF0000")
+        expect(@worksheet[1][0].get_border_color(:bottom)).to eq("FF0000")
+        expect(@worksheet[1][1].get_border_color(:bottom)).to eq("FF0000")
+      end
+    end
   end
 
   describe '.change_border' do

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -214,6 +214,104 @@ describe RubyXL::Cell do
       @cell.change_border(:diagonal, 'thin')
       expect(@cell.get_border(:diagonal)).to eq('thin')
     end
+
+    context "when the cell is merged horizontally" do
+      before :each do
+        @worksheet.merge_cells(0, 0, 0, 1)
+      end
+
+      it "should change the left border of both merged cells" do
+        @cell.change_border(:left, "thin")
+        expect(@worksheet[0][0].get_border(:left)).to eq("thin")
+        expect(@worksheet[0][1].get_border(:left)).to eq("thin")
+      end
+
+      it "should change the right border of the both merged cells" do
+        @cell.change_border(:right, "thin")
+        expect(@worksheet[0][0].get_border(:right)).to eq("thin")
+        expect(@worksheet[0][1].get_border(:right)).to eq("thin")
+      end
+
+      it "should change the top border for both merged cells" do
+        @cell.change_border(:top, "thin")
+        expect(@worksheet[0][0].get_border(:top)).to eq("thin")
+        expect(@worksheet[0][1].get_border(:top)).to eq("thin")
+      end
+
+      it "should change the bottom border for both merged cells" do
+        @cell.change_border(:bottom, "thin")
+        expect(@worksheet[0][0].get_border(:bottom)).to eq("thin")
+        expect(@worksheet[0][1].get_border(:bottom)).to eq("thin")
+      end
+    end
+
+    context "when the cell is merged vertically" do
+      before :each do
+        @worksheet.merge_cells(0, 0, 1, 0)
+      end
+
+      it "should change the left border of both merged cells" do
+        @cell.change_border(:left, "thin")
+        expect(@worksheet[0][0].get_border(:left)).to eq("thin")
+        expect(@worksheet[1][0].get_border(:left)).to eq("thin")
+      end
+
+      it "should change the right border of the both merged cells" do
+        @cell.change_border(:right, "thin")
+        expect(@worksheet[0][0].get_border(:right)).to eq("thin")
+        expect(@worksheet[1][0].get_border(:right)).to eq("thin")
+      end
+
+      it "should change the top border for both merged cells" do
+        @cell.change_border(:top, "thin")
+        expect(@worksheet[0][0].get_border(:top)).to eq("thin")
+        expect(@worksheet[1][0].get_border(:top)).to eq("thin")
+      end
+
+      it "should change the bottom border for both merged cells" do
+        @cell.change_border(:bottom, "thin")
+        expect(@worksheet[0][0].get_border(:bottom)).to eq("thin")
+        expect(@worksheet[1][0].get_border(:bottom)).to eq("thin")
+      end
+    end
+
+    context "when the cell is merged horizontally and veritically" do
+      before :each do
+        @worksheet.merge_cells(0, 0, 1, 1)
+      end
+
+      it "should change the left border of both merged cells" do
+        @cell.change_border(:left, "thin")
+        expect(@worksheet[0][0].get_border(:left)).to eq("thin")
+        expect(@worksheet[0][1].get_border(:left)).to eq("thin")
+        expect(@worksheet[1][0].get_border(:left)).to eq("thin")
+        expect(@worksheet[1][1].get_border(:left)).to eq("thin")
+      end
+
+      it "should change the right border of the both merged cells" do
+        @cell.change_border(:right, "thin")
+        expect(@worksheet[0][0].get_border(:right)).to eq("thin")
+        expect(@worksheet[0][1].get_border(:right)).to eq("thin")
+        expect(@worksheet[1][0].get_border(:right)).to eq("thin")
+        expect(@worksheet[1][1].get_border(:right)).to eq("thin")
+      end
+
+      it "should change the top border for both merged cells" do
+        @cell.change_border(:top, "thin")
+        expect(@worksheet[0][0].get_border(:top)).to eq("thin")
+        expect(@worksheet[0][1].get_border(:top)).to eq("thin")
+        expect(@worksheet[1][0].get_border(:top)).to eq("thin")
+        expect(@worksheet[1][1].get_border(:top)).to eq("thin")
+      end
+
+      it "should change the bottom border for both merged cells" do
+        @cell.change_border(:bottom, "thin")
+        expect(@worksheet[0][0].get_border(:bottom)).to eq("thin")
+        expect(@worksheet[0][1].get_border(:bottom)).to eq("thin")
+        expect(@worksheet[1][0].get_border(:bottom)).to eq("thin")
+        expect(@worksheet[1][1].get_border(:bottom)).to eq("thin")
+      end
+    end
   end
 
   describe '.value' do

--- a/spec/lib/worksheet_spec.rb
+++ b/spec/lib/worksheet_spec.rb
@@ -325,6 +325,24 @@ describe RubyXL::Worksheet do
       expect(@worksheet.get_row_border(0, :diagonal)).to eq('thin')
       expect(@worksheet[0][5].get_border(:diagonal)).to eq('thin')
     end
+
+    context "with merged cells" do
+      before :each do
+        @worksheet.merge_cells(0, 2, 1, 2)
+      end
+
+      it "should not add border outside of a merged cell when the border goes across it" do
+        @worksheet.change_row_border(0, :bottom, 'thin')
+        expect(@worksheet[0][0].get_border(:bottom)).to eq('thin')
+        expect(@worksheet[1][2].get_border(:bottom)).to be_nil
+      end
+
+      it "should add border outside of a merged cell when the border is tangential to it" do
+        @worksheet.change_row_border(1, :bottom, 'thin')
+        expect(@worksheet[1][0].get_border(:bottom)).to eq('thin')
+        expect(@worksheet[1][2].get_border(:bottom)).to eq('thin')
+      end
+    end
   end
 
   describe '.change_column_font_name' do
@@ -556,6 +574,24 @@ describe RubyXL::Worksheet do
       @worksheet.change_column_border(0, :diagonal, 'thin')
       expect(@worksheet.get_column_border(0, :diagonal)).to eq('thin')
       expect(@worksheet[5][0].get_border(:diagonal)).to eq('thin')
+    end
+
+    context "with merged cells" do
+      before :each do
+        @worksheet.merge_cells(2, 0, 2, 1)
+      end
+
+      it "should not add border outside of a merged cell when the border goes across it" do
+        @worksheet.change_column_border(0, :right, 'thin')
+        expect(@worksheet[0][0].get_border(:right)).to eq('thin')
+        expect(@worksheet[2][1].get_border(:right)).to be_nil
+      end
+
+      it "should add border outside of a merged cell when the border is tangential to it" do
+        @worksheet.change_column_border(1, :bottom, 'thin')
+        expect(@worksheet[0][1].get_border(:bottom)).to eq('thin')
+        expect(@worksheet[2][1].get_border(:bottom)).to eq('thin')
+      end
     end
   end
 

--- a/spec/lib/worksheet_spec.rb
+++ b/spec/lib/worksheet_spec.rb
@@ -345,6 +345,70 @@ describe RubyXL::Worksheet do
     end
   end
 
+  describe '.change_row_border_color' do
+
+    it 'should cause error if a negative argument is passed in' do
+      expect {
+        @worksheet.change_row_border_color(-1, :left, 'FF0000')
+      }.to raise_error(RuntimeError)
+    end
+
+    it 'should create a new row if it did not exist before' do
+      expect(@worksheet.sheet_data[11]).to be_nil
+      @worksheet.change_row_border_color(11, :left, 'FF0000')
+      expect(@worksheet.sheet_data[11]).to be_a(RubyXL::Row)
+      expect(@worksheet.get_row_border_color(11, :left)).to eq('FF0000')
+    end
+
+    it 'should cause row and cells to have border color at top of specified weight' do
+      @worksheet.change_row_border_color(0, :top, 'FF0000')
+      expect(@worksheet.get_row_border_color(0, :top)).to eq('FF0000')
+      expect(@worksheet[0][5].get_border_color(:top)).to eq('FF0000')
+    end
+
+    it 'should cause row and cells to have border color at left of specified weight' do
+      @worksheet.change_row_border_color(0, :left, 'FF0000')
+      expect(@worksheet.get_row_border_color(0, :left)).to eq('FF0000')
+      expect(@worksheet[0][5].get_border_color(:left)).to eq('FF0000')
+    end
+
+    it 'should cause row and cells to have border color at right of specified weight' do
+      @worksheet.change_row_border_color(0, :right, 'FF0000')
+      expect(@worksheet.get_row_border_color(0, :right)).to eq('FF0000')
+      expect(@worksheet[0][5].get_border_color(:right)).to eq('FF0000')
+    end
+
+    it 'should cause row to have border color at bottom of specified weight' do
+      @worksheet.change_row_border_color(0, :bottom, 'FF0000')
+      expect(@worksheet.get_row_border_color(0, :bottom)).to eq('FF0000')
+      expect(@worksheet[0][5].get_border_color(:bottom)).to eq('FF0000')
+    end
+
+    it 'should cause row to have border color at diagonal of specified weight' do
+      @worksheet.change_row_border_color(0, :diagonal, 'FF0000')
+      expect(@worksheet.get_row_border_color(0, :diagonal)).to eq('FF0000')
+      expect(@worksheet[0][5].get_border_color(:diagonal)).to eq('FF0000')
+    end
+
+    context "with merged cells" do
+      before :each do
+        @worksheet.merge_cells(0, 2, 1, 2)
+      end
+
+      it "should not add border color outside of a merged cell when the border goes across it" do
+        @worksheet.change_row_border_color(0, :bottom, 'FF0000')
+        expect(@worksheet[0][0].get_border_color(:bottom)).to eq('FF0000')
+        expect(@worksheet[1][2].get_border_color(:bottom)).to be_nil
+      end
+
+      it "should add border color outside of a merged cell when the border is tangential to it" do
+        @worksheet.change_row_border_color(1, :bottom, 'FF0000')
+        expect(@worksheet[1][0].get_border_color(:bottom)).to eq('FF0000')
+        expect(@worksheet[1][2].get_border_color(:bottom)).to eq('FF0000')
+      end
+    end
+  end
+
   describe '.change_column_font_name' do
     it 'should cause column and cell font names to match string passed in' do
       @worksheet.change_column_font_name(0, 'Arial')
@@ -591,6 +655,62 @@ describe RubyXL::Worksheet do
         @worksheet.change_column_border(1, :bottom, 'thin')
         expect(@worksheet[0][1].get_border(:bottom)).to eq('thin')
         expect(@worksheet[2][1].get_border(:bottom)).to eq('thin')
+      end
+    end
+  end
+
+  describe '.change_column_border_color' do
+    it 'should cause error if a negative argument is passed in' do
+      expect {
+        @worksheet.change_column_border_color(-1, :top, 'FF0000')
+      }.to raise_error(RuntimeError)
+    end
+
+    it 'should cause column and cells wiFF0000 to have border color at top of specified weight' do
+      @worksheet.change_column_border_color(0, :top, 'FF0000')
+      expect(@worksheet.get_column_border_color(0, :top)).to eq('FF0000')
+      expect(@worksheet[5][0].get_border_color(:top)).to eq('FF0000')
+    end
+
+    it 'should cause column and cells wiFF0000 to have border color at left of specified weight' do
+      @worksheet.change_column_border_color(0, :left, 'FF0000')
+      expect(@worksheet.get_column_border_color(0, :left)).to eq('FF0000')
+      expect(@worksheet[5][0].get_border_color(:left)).to eq('FF0000')
+    end
+
+    it 'should cause column and cells wiFF0000 to have border color at right of specified weight' do
+      @worksheet.change_column_border_color(0, :right, 'FF0000')
+      expect(@worksheet.get_column_border_color(0, :right)).to eq('FF0000')
+      expect(@worksheet[5][0].get_border_color(:right)).to eq('FF0000')
+    end
+
+    it 'should cause column and cells wiFF0000 to have border color at bottom of specified weight' do
+      @worksheet.change_column_border_color(0, :bottom, 'FF0000')
+      expect(@worksheet.get_column_border_color(0, :bottom)).to eq('FF0000')
+      expect(@worksheet[5][0].get_border_color(:bottom)).to eq('FF0000')
+    end
+
+    it 'should cause column and cells wiFF0000 to have border color at diagonal of specified weight' do
+      @worksheet.change_column_border_color(0, :diagonal, 'FF0000')
+      expect(@worksheet.get_column_border_color(0, :diagonal)).to eq('FF0000')
+      expect(@worksheet[5][0].get_border_color(:diagonal)).to eq('FF0000')
+    end
+
+    context "with merged cells" do
+      before :each do
+        @worksheet.merge_cells(2, 0, 2, 1)
+      end
+
+      it "should not add border color outside of a merged cell when the border goes across it" do
+        @worksheet.change_column_border_color(0, :right, 'FF0000')
+        expect(@worksheet[0][0].get_border_color(:right)).to eq('FF0000')
+        expect(@worksheet[2][1].get_border_color(:right)).to be_nil
+      end
+
+      it "should add border color outside of a merged cell when the border is tangential to it" do
+        @worksheet.change_column_border_color(1, :bottom, 'FF0000')
+        expect(@worksheet[0][1].get_border_color(:bottom)).to eq('FF0000')
+        expect(@worksheet[2][1].get_border_color(:bottom)).to eq('FF0000')
       end
     end
   end


### PR DESCRIPTION
These changes make it so that changing the border of a merged cell applies to the entire merged area. For example, setting border right on a cell merged horizontally over multiple columns will set the border on the cell as expected. The same goes for border colors.