### PR TITLE
Fix invalid XML escaping of U+10000 to U+10FFFF character range

### DIFF
--- a/lib/rubyXL/objects/text.rb
+++ b/lib/rubyXL/objects/text.rb
@@ -14,7 +14,7 @@ module RubyXL
     # http://www.w3.org/TR/REC-xml/#NT-Char:
     # Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
 
-    INVALID_XML10_CHARS = /([^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF])/
+    INVALID_XML10_CHARS = /([^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}])/
     ESCAPED_UNICODE = /_x([0-9A-F]{4})_/
 
     def before_write_xml

--- a/spec/lib/text_spec.rb
+++ b/spec/lib/text_spec.rb
@@ -16,6 +16,14 @@ describe RubyXL::Text do
       expect(str).to be
     end
 
+    it 'should not escape valid XML extended UNICODE characters' do
+      t = RubyXL::Text.new(:value => "\u{10000}\u{10FFFF}")
+
+      xml = t.write_xml[/<t>[^<]+<\/t>/]
+
+      expect(xml).to eq("<t>\u{10000}\u{10FFFF}</t>")
+    end
+
   end
 
 end


### PR DESCRIPTION
This fixes a bug in the regular expression for escaping invalid XML characters.

Ruby requires the special syntax `\u{hex}` for matching unicode character with more than 4 bytes.

Because of this the regex range `[^\u10000-\u10FFFF]` was interpreted as `[^\u1000]|[^0-\u10FF]|[^FF]`.

I found this bug because `RUBYOPT=-W3` triggered a duplicate character range warning for the regex.