### PR TITLE
Support inlineStr cells

### DIFF
--- a/lib/rubyXL/objects/sheet_data.rb
+++ b/lib/rubyXL/objects/sheet_data.rb
@@ -80,6 +80,7 @@ module RubyXL
 
       case datatype
       when RubyXL::DataType::SHARED_STRING then workbook.shared_strings_container[r.to_i].to_s
+      when RubyXL::DataType::INLINE_STRING then is.to_s
       when RubyXL::DataType::RAW_STRING    then raw_value
       else
         if is_date? then workbook.num_to_date(r.to_f)

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -314,6 +314,16 @@ describe RubyXL::Cell do
         expect(@cell.value).to eq(DateTime.parse('1899-12-31 00:28:02'))
       end
     end
+
+    context 'inlineStr' do
+      it 'should return the value of inline string cells' do
+        @cell.datatype = 'inlineStr'
+        @cell.value_container = nil
+        @cell.is = RubyXL::RichText.new(:t => RubyXL::Text.new(:value => 'Hello'))
+
+        expect(@cell.value).to eq('Hello')
+      end
+    end
   end
 
   describe '.change_contents' do


### PR DESCRIPTION
Cell `value` for `inlineStr` cells was always `nil`. Here is a small change to make `value` return the string contents of such cells.

Example for a spreadsheet with an `inlineStr` cell:

    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
      <sheetData>
        <row r="1">
          <c r="A1" t="inlineStr">
            <is>
              <t>Hello</t>
            </is>
          </c>
        </row>
      </sheetData>
    </worksheet>

I am not sure on how to properly generate the XML structure for the spec, so I'll gladly adjust if there is a better way. :)