### PR TITLE
Suppress warning

### DIFF
--- a/spec/lib/workbook_spec.rb
+++ b/spec/lib/workbook_spec.rb
@@ -136,7 +136,6 @@ describe RubyXL::Workbook do
     it "It should not be confused by missing sheet_id" do
       workbook = RubyXL::Workbook.new
       workbook[0].sheet_id = 1
-      sheet = workbook.add_worksheet('Sheet2')
       workbook.stream
     end
 


### PR DESCRIPTION
This PR suppresses the following warning.

```
ruby -v
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin16]

RUBYOPT=-w bundle exec rake 
/Users/numata/git/github.com/weshatheleopard/rubyXL/spec/lib/workbook_spec.rb:139: warning: assigned but unused variable - sheet
```