### PR TITLE
Support Ruby 2.5.0

### DIFF
--- a/spec/lib/parser_spec.rb
+++ b/spec/lib/parser_spec.rb
@@ -41,7 +41,8 @@ describe RubyXL::Parser do
     @workbook.modified_at = @time2
 
     @time_str = Time.now.to_s
-    @file = Dir::Tmpname.make_tmpname(['rubyXL', '.xlsx'], nil)
+    t = Time.now.strftime("%Y%m%d")
+    @file = "rubyXL-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}.xlsx"
     @workbook.write(@file)
   end
 


### PR DESCRIPTION
I replaced the call to `Dir::Tmpname.make_tmpname` as that is deprecated in Ruby 2.5 https://github.com/ruby/ruby/commit/25d56ea7b7b52dc81af30c92a9a0e2d2dab6ff27

I just copied what the Rails project did, https://github.com/rails/rails/pull/31462/files

