### PR TITLE
Add xr:revisionPtr extension

### DIFF
--- a/lib/rubyXL/objects/extensions.rb
+++ b/lib/rubyXL/objects/extensions.rb
@@ -32,5 +32,9 @@ module RubyXL
   class AlternateContent < RawOOXML
     define_element_name 'mc:AlternateContent'
   end
+  
+  class RevisionPtr < RawOOXML
+    define_element_name 'xr:revisionPtr'
+  end
 
 end

--- a/lib/rubyXL/objects/workbook.rb
+++ b/lib/rubyXL/objects/workbook.rb
@@ -333,6 +333,7 @@ module RubyXL
     define_child_node(RubyXL::FileSharing)
     define_child_node(RubyXL::WorkbookProperties, :accessor => :workbook_properties)
     define_child_node(RubyXL::AlternateContent) # Somehow, order matters here
+    define_child_node(RubyXL::RevisionPtr)
     define_child_node(RubyXL::WorkbookProtection)
     define_child_node(RubyXL::WorkbookViews)
     define_child_node(RubyXL::Sheets)


### PR DESCRIPTION
This fixes the error:
```
Unknown child node [xr:revisionPtr] for element [workbook] (RuntimeError)
```

Caused by the following added to the workbook.xml file
```
<xr:revisionPtr revIDLastSave="0" documentId="13_ncr:1_{A6B798D1-9397-4842-BF77-DA1694BBFC0E}" xr6:coauthVersionLast="28" xr6:coauthVersionMax="28" xr10:uidLastSave="{00000000-0000-0000-0000-000000000000}"/>
```