### PR TITLE
Reference xr:revisionPtr element in Workbook

### DIFF
--- a/lib/rubyXL/objects/extensions.rb
+++ b/lib/rubyXL/objects/extensions.rb
@@ -33,4 +33,8 @@ module RubyXL
     define_element_name 'mc:AlternateContent'
   end
 
+  class RevisionPointer < RawOOXML
+    define_element_name 'xr:revisionPtr'
+  end
+
 end

--- a/lib/rubyXL/objects/workbook.rb
+++ b/lib/rubyXL/objects/workbook.rb
@@ -333,6 +333,7 @@ module RubyXL
     define_child_node(RubyXL::FileSharing)
     define_child_node(RubyXL::WorkbookProperties, :accessor => :workbook_properties)
     define_child_node(RubyXL::AlternateContent) # Somehow, order matters here
+    define_child_node(RubyXL::RevisionPointer)
     define_child_node(RubyXL::WorkbookProtection)
     define_child_node(RubyXL::WorkbookViews)
     define_child_node(RubyXL::Sheets)


### PR DESCRIPTION
Microsoft have started including this element in the workbook.xml file for newest versions of Excel.  Without this reference, parsing by rubyXL fails.

https://msdn.microsoft.com/en-us/library/mt793297(v=office.12).aspx