### PR TITLE
Bugfix add_cell to work with unspecified types like symbols and dates

### DIFF
--- a/lib/rubyXL/worksheet.rb
+++ b/lib/rubyXL/worksheet.rb
@@ -49,13 +49,13 @@ module LegacyWorksheet
       else
         case data
         when Numeric          then c.raw_value = data
-        when String           then
-          c.raw_value = data
-          c.datatype = RubyXL::DataType::RAW_STRING
         when RubyXL::RichText then
           c.is = data
           c.datatype = RubyXL::DataType::INLINE_STRING
         when NilClass         then nil
+        else
+          c.raw_value = data
+          c.datatype = RubyXL::DataType::RAW_STRING
         end
       end
 

--- a/spec/lib/worksheet_spec.rb
+++ b/spec/lib/worksheet_spec.rb
@@ -573,6 +573,17 @@ describe RubyXL::Worksheet do
       expect(@worksheet[0][0].value).to eq('TEST')
     end
 
+    it 'should work with symbols' do
+      @worksheet.add_cell(0,0, :TEST)
+      expect(@worksheet[0][0].value).to eq(:TEST)
+    end
+
+    it 'should work with dates' do
+      dt = Date.new
+      @worksheet.add_cell(0,0, dt)
+      expect(@worksheet[0][0].value).to eq(dt)
+    end
+
     it 'should add a new cell below nil rows that might exist' do
       @worksheet.sheet_data.rows << nil << nil
       @worksheet.add_cell(15,0, 'TEST')


### PR DESCRIPTION
An older version of the add_cell method wrote the raw_value to whatever the data was. With the current version only Numeric, String, RubyXL::RichText, and NilClass are checked. This results in cells with symbols and dates being empty.

Was there a specific reason that those types were ignored? If not, this pull request mimics the original functionality for those types.