### PR TITLE
Adds support for 'xr:revisionPtr'

### DIFF
--- a/lib/rubyXL/objects/extensions.rb
+++ b/lib/rubyXL/objects/extensions.rb
@@ -35,8 +35,6 @@ module RubyXL
   
   class RevisionPtr < RawOOXML
     define_element_name 'xr:revisionPtr'
-    define_attribute(:revIDLastSave, :string)
-    define_attribute(:documentId, :string)
   end
 
   class OOXMLIgnored < OOXMLObject

--- a/lib/rubyXL/objects/extensions.rb
+++ b/lib/rubyXL/objects/extensions.rb
@@ -32,6 +32,12 @@ module RubyXL
   class AlternateContent < RawOOXML
     define_element_name 'mc:AlternateContent'
   end
+  
+  class RevisionPtr < RawOOXML
+    define_element_name 'xr:revisionPtr'
+    define_attribute(:revIDLastSave, :string)
+    define_attribute(:documentId, :string)
+  end
 
   class OOXMLIgnored < OOXMLObject
     def self.parse(node, ignore)

--- a/lib/rubyXL/objects/workbook.rb
+++ b/lib/rubyXL/objects/workbook.rb
@@ -350,6 +350,7 @@ module RubyXL
     define_child_node(RubyXL::FileRecoveryProperties)
     define_child_node(RubyXL::WebPublishObjects)
     define_child_node(RubyXL::ExtensionStorageArea)
+    define_child_node(RubyXL::RevisionPtr)
 
     define_element_name 'workbook'
     set_namespaces('http://schemas.openxmlformats.org/spreadsheetml/2006/main' => nil,


### PR DESCRIPTION
Hi there,

Thanks very much for a very useful library that have proven important in a project of mine.

I encountered a problem where the definition of OOXML objects in rubyXL lacked support for the `xr:revisionPtr` element, so I added it. 😃 

Best,
Thomas