### PR TITLE
Add safe navigation operator

### DIFF
--- a/lib/rubyXL/convenience_methods.rb
+++ b/lib/rubyXL/convenience_methods.rb
@@ -151,7 +151,7 @@ module RubyXL
 
     def modify_alignment(style_index, &block)
       xf = cell_xfs[style_index || 0].dup
-      xf.alignment = xf.alignment.dup || RubyXL::Alignment.new
+      xf.alignment = xf.alignment&.dup || RubyXL::Alignment.new
       yield(xf.alignment)
       xf.apply_alignment = true
 


### PR DESCRIPTION
This pull request addresses https://github.com/weshatheleopard/rubyXL/issues/317, where `nil.dup` results in an error. It is addressed by using `:&` in case there is no existing alignment.

This bug was introduced in [this commit](https://github.com/weshatheleopard/rubyXL/commit/b7601cfcca8a54c2bfea24275665bfc34a48c23f) which was meant to resolve this issue https://github.com/weshatheleopard/rubyXL/issues/315