### PR TITLE
Adding support for QueryTable and external Connections

### DIFF
--- a/lib/rubyXL/objects/connection.rb
+++ b/lib/rubyXL/objects/connection.rb
@@ -1,0 +1,175 @@
+require 'rubyXL/objects/ooxml_object'
+require 'rubyXL/objects/simple_types'
+require 'rubyXL/objects/extensions'
+
+# Connections
+# https://msdn.microsoft.com/en-us/library/dd908547(v=office.12).aspx
+# http://www.datypic.com/sc/ooxml/s-sml-externalConnections.xsd.html
+
+module RubyXL
+  # http://www.datypic.com/sc/ooxml/e-ssml_dbPr-1.html
+  class OdbcOleDbProperties < OOXMLObject
+    define_attribute(:connection, RubyXL::ST_Xstring, :required => true)
+    define_attribute(:command	, RubyXL::ST_Xstring)
+    define_attribute(:serverCommand, RubyXL::ST_Xstring)
+    define_attribute(:commandType, :uint, :default => 2)
+
+    define_element_name 'dbPr'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_olapPr-1.html
+  class OlapProperties < OOXMLObject
+    define_attribute(:local, :bool, :default => false)
+    define_attribute(:localConnection, RubyXL::ST_Xstring)
+    define_attribute(:localRefresh, :bool, :default => true)
+    define_attribute(:sendLocale, :bool, :default => false)
+    define_attribute(:rowDrillCount, :uint)
+    define_attribute(:serverFill, :bool, :default => true)
+    define_attribute(:serverNumberFormat, :bool, :default => true)
+    define_attribute(:serverFont, :bool, :default => true)
+    define_attribute(:serverFontColor, :bool, :default => true)
+
+    define_element_name 'olapPr'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_s-1.html
+  # TODO: ssml:m & ssml:x... but how?
+  class ConnectionTable < OOXMLObject
+    define_attribute(:v, RubyXL::ST_Xstring, :required => true)
+
+    define_element_name 's'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_tables-1.html
+  class ConnectionTables < OOXMLObject
+    define_child_node(RubyXL::ConnectionTable, :collection => :with_count, :accessor => :tables, :node_name => :table)
+    define_element_name 'tables'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_webPr-1.html
+  class WebQueryProperties < OOXMLObject
+    define_attribute(:xml, :bool, :default => false)
+    define_attribute(:sourceData, :bool, :default => false)
+    define_attribute(:parsePre, :bool, :default => false)
+    define_attribute(:consecutive, :bool, :default => false)
+    define_attribute(:firstRow, :bool, :default => false)
+    define_attribute(:xl97, :bool, :default => false)
+    define_attribute(:textDates, :bool, :default => false)
+    define_attribute(:xl2000, :bool, :default => false)
+    define_attribute(:url, RubyXL::ST_Xstring)
+    define_attribute(:post, RubyXL::ST_Xstring)
+    define_attribute(:htmlTables, :bool, :default => false)
+    define_attribute(:htmlFormat, ssml:ST_HtmlFmt, :default => "none")
+    define_attribute(:editPage, RubyXL::ST_Xstring)
+
+    define_child_node(RubyXL::ConnectionTables)
+
+    define_element_name 'webPr'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_textField-1.html
+  class ConnectionTextField < OOXMLObject
+    define_attribute(:type, RubyXL::ST_ExternalConnectionType, :default => "general")
+    define_attribute(:position, :uint, :default => 0)
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_textFields-1.html
+  class ConnectionTextFields < OOXMLObject
+    define_child_node(RubyXL::ConnectionTextField, :collection => :with_count, :accessor => :textFields, :node_name => :textField)
+
+    define_element_name 'textFields'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_textPr-1.html
+  class TextImportSettings < OOXMLObject
+    define_attribute(:prompt, :bool, :default => true)
+    define_attribute(:fileType, ssml:ST_FileType, :default => "win")
+    define_attribute(:codePage, :uint, :default => 1252)
+    define_attribute(:firstRow, :uint, :default => 1)
+    define_attribute(:sourceFile, RubyXL::ST_Xstring, :default => "")
+    define_attribute(:delimited, :bool, :default => true)
+    define_attribute(:decimal, RubyXL::ST_Xstring, :default => ".")
+    define_attribute(:thousands, RubyXL::ST_Xstring, :default => ",")
+    define_attribute(:tab, :bool, :default => true)
+    define_attribute(:space, :bool, :default => false)
+    define_attribute(:comma, :bool, :default => false)
+    define_attribute(:semicolon, :bool, :default => false)
+    define_attribute(:consecutive, :bool, :default => false)
+    define_attribute(:qualifier, ssml:ST_Qualifier, :default => "doubleQuote")
+    define_attribute(:delimiter, RubyXL::ST_Xstring)
+
+    define_child_node(RubyXL::ConnectionTextFields)
+
+    define_element_name 'textPr'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_parameter-1.html
+  class QueryParameter < OOXMLObject
+    define_attribute(:name, RubyXL::ST_Xstring)
+    define_attribute(:sqlType, :int, :default => 0)
+    define_attribute(:parameterType, RubyXL::ST_ParameterType, :default => "prompt")
+    define_attribute(:refreshOnChange, :bool, :default => false)
+    define_attribute(:prompt, RubyXL::ST_Xstring)
+    define_attribute(:boolean, :bool)
+    define_attribute(:double, :double)
+    define_attribute(:integer, :int)
+    define_attribute(:string, RubyXL::ST_Xstring)
+    define_attribute(:cell, RubyXL::ST_Xstring)
+    define_element_name 'parameter'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_parameters-1.html
+  class QueryParameters < OOXMLObject
+    define_child_node(RubyXL::QueryParameter, :collection => :with_count, :accessor => :parameters, :node_name => :parameter)
+    define_element_name 'parameters'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_connection-1.html
+  class Connection < OOXMLObject
+    define_attribute(:id, :uint, :required => true)
+    define_attribute(:sourceFile, RubyXL::ST_Xstring)
+    define_attribute(:odcFile, RubyXL::ST_Xstring)
+    define_attribute(:keepAlive, :bool, :default => false)
+    define_attribute(:interval, :uint, :default => 0)
+    define_attribute(:name, RubyXL::ST_Xstring)
+    define_attribute(:description, RubyXL::ST_Xstring)
+    define_attribute(:type, :uint)
+    define_attribute(:reconnectionMethod, :uint, :default => 1)
+    define_attribute(:refreshedVersion, :uint, :required => true)
+    define_attribute(:minRefreshableVersion, :uint, :default => 0)
+    define_attribute(:savePassword, :bool, :default => false)
+    define_attribute(:new, :bool, :default => false)
+    define_attribute(:deleted, :bool, :default => false)
+    define_attribute(:onlyUseConnectionFile, :bool, :default => false)
+    define_attribute(:background, :bool, :default => false)
+    define_attribute(:refreshOnLoad, :bool, :default => false)
+    define_attribute(:saveData, :bool, :default => false)
+    define_attribute(:credentials, RubyXL::ST_CredMethod, :default => "integrated")
+    define_attribute(:singleSignOnId, RubyXL::ST_Xstring)
+
+    define_child_node(RubyXL::OdbcOleDbProperties)
+    define_child_node(RubyXL::OlapProperties)
+    define_child_node(RubyXL::WebQueryProperties)
+    define_child_node(RubyXL::TextImportSettings)
+    define_child_node(RubyXL::QueryParameters)
+    define_child_node(RubyXL::ExtensionStorageArea)
+
+    define_element_name 'connection'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_connections.html
+  class Connections < OOXMLTopLevelObject
+    CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.connections+xml'
+    REL_TYPE     = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/connections'
+
+    define_child_node(RubyXL::Connection, :collection => true, :accessor => :connections)
+
+    define_element_name 'connections'
+
+    set_namespaces('http://schemas.openxmlformats.org/spreadsheetml/2006/main' => nil)
+
+    def xlsx_path
+      ROOT.join('xl', 'connections.xml')
+    end
+  end
+end

--- a/lib/rubyXL/objects/query_table.rb
+++ b/lib/rubyXL/objects/query_table.rb
@@ -1,0 +1,104 @@
+require 'rubyXL/objects/ooxml_object'
+require 'rubyXL/objects/simple_types'
+require 'rubyXL/objects/extensions'
+require 'rubyXL/objects/relationships'
+require 'rubyXL/objects/sheet_common'
+
+# Query Tables
+# https://msdn.microsoft.com/en-us/library/hh643563(v=office.12).aspx
+
+module RubyXL
+  # http://www.datypic.com/sc/ooxml/e-ssml_queryTableField-1.html
+  class QueryTableField < OOXMLObject
+    define_attribute(:id, :uint, :required => true)
+    define_attribute(:name, RubyXL::ST_Xstring)
+    define_attribute(:dataBound, :bool, :default => true)
+    define_attribute(:rowNumbers, :bool, :default => false)
+    define_attribute(:fillFormulas, :bool, :default => false)
+    define_attribute(:clipped, :bool, :default => false)
+    define_attribute(:tableColumnId, :uint, :default => 0)
+
+    define_child_node(RubyXL::ExtensionStorageArea)
+
+    define_element_name 'queryTableField'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_queryTableFields-1.html
+  class QueryTableFields < OOXMLObject
+    define_child_node(RubyXL::QueryTableField, :collection => :with_count, :accessor => :queryTableFields, :node_name => :queryTableField)
+    define_element_name 'queryTableFields'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_deletedField-1.html
+  class QueryTableDeletedField < OOXMLObject
+    define_attribute(:name, RubyXL::ST_Xstring, :required => true)
+
+    define_element_name 'deletedField'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_queryTableDeletedFields-1.html
+  class QueryTableDeletedFields < OOXMLObject
+    define_child_node(RubyXL::QueryTableDeletedField, :collection => :with_count, :accessor => :queryTableDeletedFields, :node_name => :deletedField)
+    define_element_name 'queryTableDeletedFields'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_queryTableRefresh-1.html
+  class QueryTableRefresh < OOXMLObject
+    define_attribute(:preserveSortFilterLayout, :bool, :default => true)
+    define_attribute(:fieldIdWrapped, :bool, :default => false)
+    define_attribute(:headersInLastRefresh, :bool, :default => true)
+    define_attribute(:minimumVersion, :uint, :default => 0)
+    define_attribute(:nextId, :uint, :default => 1)
+    define_attribute(:unboundColumnsLeft, :uint, :default => 0)
+    define_attribute(:unboundColumnsRight, :uint, :default => 0)
+
+    define_child_node(RubyXL::QueryTableFields) # [1..1]
+    define_child_node(RubyXL::QueryTableDeletedFields)
+    define_child_node(RubyXL::SortState)
+    define_child_node(RubyXL::ExtensionStorageArea)
+
+    define_element_name 'queryTableRefresh'
+  end
+
+  # http://www.datypic.com/sc/ooxml/e-ssml_queryTable.html
+  class QueryTable < OOXMLTopLevelObject
+    CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.queryTable+xml'
+    REL_TYPE     = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/queryTable'
+
+    include RubyXL::RelationshipSupport
+
+    define_attribute(:name, RubyXL::ST_Xstring, :required => true)
+    define_attribute(:headers, :bool, :default => true)
+    define_attribute(:rowNumbers, :bool, :default => false)
+    define_attribute(:disableRefresh, :bool, :default => false)
+    define_attribute(:backgroundRefresh, :bool, :default => true)
+    define_attribute(:firstBackgroundRefresh, :bool, :default => false)
+    define_attribute(:refreshOnLoad, :bool, :default => false)
+    define_attribute(:growShrinkType, RubyXL::ST_GrowShrinkType, :default => "insertDelete")
+    define_attribute(:fillFormulas, :bool, :default => false)
+    define_attribute(:removeDataOnSave, :bool, :default => false)
+    define_attribute(:disableEdit, :bool, :default => false)
+    define_attribute(:preserveFormatting, :bool, :default => true)
+    define_attribute(:adjustColumnWidth, :bool, :default => true)
+    define_attribute(:intermediate, :bool, :default => false)
+    define_attribute(:connectionId, :uint, :required => true)
+    define_attribute(:autoFormatId, :uint)
+    define_attribute(:applyNumberFormats, :bool)
+    define_attribute(:applyBorderFormats, :bool)
+    define_attribute(:applyFontFormats, :bool)
+    define_attribute(:applyPatternFormats, :bool)
+    define_attribute(:applyAlignmentFormats, :bool)
+    define_attribute(:applyWidthHeightFormats, :bool)
+
+    define_child_node(RubyXL::QueryTableRefresh)
+    define_child_node(RubyXL::ExtensionStorageArea)
+
+    define_element_name 'queryTable'
+    set_namespaces('http://schemas.openxmlformats.org/spreadsheetml/2006/main' => nil,
+                   'http://schemas.openxmlformats.org/officeDocument/2006/relationships' => 'r')
+
+    def xlsx_path
+      ROOT.join('xl', 'queryTables', "queryTable#{file_index}.xml")
+    end
+  end
+end

--- a/lib/rubyXL/objects/simple_types.rb
+++ b/lib/rubyXL/objects/simple_types.rb
@@ -235,4 +235,13 @@ module RubyXL
 
   # Query Tables
   ST_GrowShrinkType = %w{ insertDelete insertClear overwriteClear }
+
+  # Connections
+  ST_CredMethod = %w{ integrated none stored prompt }
+  ST_ParameterType = %w{ prompt value cell }
+  ST_FileType = %w{ mac win dos }
+  ST_Qualifier = %w{ doubleQuote singleQuote none }
+  ST_ExternalConnectionType = %w{ general text MDY DMY YMD MYD DYM YDM skip EMD }
+
+  ST_HtmlFmt = %w{ none rtf all }
 end

--- a/lib/rubyXL/objects/simple_types.rb
+++ b/lib/rubyXL/objects/simple_types.rb
@@ -231,4 +231,8 @@ module RubyXL
   # TODO: http://www.datypic.com/sc/ooxml/t-ssml_ST_UnsignedShortHex.html
   ST_UnsignedShortHex     = :string # length = 2
 
+  ST_Xstring = :string
+
+  # Query Tables
+  ST_GrowShrinkType = %w{ insertDelete insertClear overwriteClear }
 end

--- a/lib/rubyXL/objects/workbook.rb
+++ b/lib/rubyXL/objects/workbook.rb
@@ -7,6 +7,7 @@ require 'rubyXL/objects/theme'
 require 'rubyXL/objects/calculation_chain'
 require 'rubyXL/objects/worksheet'
 require 'rubyXL/objects/chartsheet'
+require 'rubyXL/objects/connection'
 require 'rubyXL/objects/relationships'
 require 'rubyXL/objects/simple_types'
 require 'rubyXL/objects/extensions'
@@ -321,6 +322,7 @@ module RubyXL
     define_relationship(RubyXL::CalculationChain,   :calculation_chain)
     define_relationship(RubyXL::Worksheet,          false)
     define_relationship(RubyXL::Chartsheet,         false)
+    define_relationship(RubyXL::Connections)
     define_relationship(RubyXL::ExternalLinksFile)
     define_relationship(RubyXL::PivotCacheDefinitionFile)
     define_relationship(RubyXL::PivotCacheRecordsFile)

--- a/lib/rubyXL/objects/worksheet.rb
+++ b/lib/rubyXL/objects/worksheet.rb
@@ -10,6 +10,7 @@ require 'rubyXL/objects/column_range'
 require 'rubyXL/objects/filters'
 require 'rubyXL/objects/data_validation'
 require 'rubyXL/objects/comments'
+require 'rubyXL/objects/connection'
 require 'rubyXL/objects/query_table'
 require 'rubyXL/worksheet'
 

--- a/lib/rubyXL/objects/worksheet.rb
+++ b/lib/rubyXL/objects/worksheet.rb
@@ -10,6 +10,7 @@ require 'rubyXL/objects/column_range'
 require 'rubyXL/objects/filters'
 require 'rubyXL/objects/data_validation'
 require 'rubyXL/objects/comments'
+require 'rubyXL/objects/query_table'
 require 'rubyXL/worksheet'
 
 module RubyXL
@@ -633,6 +634,7 @@ module RubyXL
     define_relationship(RubyXL::SlicerFile)
     define_relationship(RubyXL::OLEObjectFile)
     define_relationship(RubyXL::ActiveX)
+    define_relationship(RubyXL::QueryTable)
 
     define_child_node(RubyXL::WorksheetProperties)
     define_child_node(RubyXL::WorksheetDimensions)


### PR DESCRIPTION
I have a need to read/write XLSM files which make use of QueryTable and Connections. I wanted to add support for these structures to RubyXL and ensure that references are not broken on write, thus corrupting the output file. 

I am not 100% sure if what I have done is correct, please let me know if there is something wrong or missing. The below changes do now allow me to read and write files containing these entities.