### PR TITLE
An option to silence warnings

### DIFF
--- a/lib/rubyXL/objects/relationships.rb
+++ b/lib/rubyXL/objects/relationships.rb
@@ -82,7 +82,7 @@ module RubyXL
         klass = RubyXL::OOXMLRelationshipsFile.get_class_by_rel_type(rel.type)
 
         if klass.nil? then
-          puts "*** WARNING: storage class not found for #{rel.target} (#{rel.type})"
+          puts "*** WARNING: storage class not found for #{rel.target} (#{rel.type})" if RubyXL::WorkbookRoot.class_variable_get(:@@warn)
           klass = GenericStorageObject
         end
 
@@ -204,7 +204,7 @@ module RubyXL
 
     def store_relationship(related_file, unknown = false)
       self.generic_storage ||= []
-      puts "WARNING: #{self.class} is not aware what to do with #{related_file.class}" if unknown
+      puts "WARNING: #{self.class} is not aware what to do with #{related_file.class}" if unknown && RubyXL::WorkbookRoot.class_variable_get(:@@warn)
       self.generic_storage << related_file
     end
 

--- a/lib/rubyXL/objects/root.rb
+++ b/lib/rubyXL/objects/root.rb
@@ -8,6 +8,7 @@ module RubyXL
 
   class WorkbookRoot
     @@debug = $DEBUG
+    @@warn = true
 
     attr_accessor :source_file_path, :content_types, :rels_hash
 


### PR DESCRIPTION
Hi, please consider adding the option to silence warnings. Since the errors aren't critical it will be of use in production environments. The changes are in line with the way you treat the debug info, however I would suggest changing ```puts``` to ```warn``` and setting up a class-level config object, so something like ```RubyXL.settings.debug = true``` would be possible. What do you think?