### PR TITLE
RichText#to_s crashes in Ruby 2.7 for RichText objects

### DIFF
--- a/lib/rubyXL/objects/text.rb
+++ b/lib/rubyXL/objects/text.rb
@@ -86,7 +86,7 @@ module RubyXL
 
     def to_s
       str = t.to_s
-      r && r.each { |rtr| str << rtr.to_s if rtr }
+      r && r.each { |rtr| str += rtr.to_s if rtr }
       str
     end
   end


### PR DESCRIPTION
Because nil.to_s returns a frozen empty string in ruby 2.7: https://bugs.ruby-lang.org/issues/16150

Didn't find a way to create a spec for this I'm afraid.