### PR TITLE
Avoid warning after setting creator or modifier when opening in excel

### DIFF
--- a/lib/rubyXL/objects/document_properties.rb
+++ b/lib/rubyXL/objects/document_properties.rb
@@ -127,7 +127,7 @@ module RubyXL
     end
 
     def creator=(v)
-      self.dc_creator = v && RubyXL::StringNodeW3C.new(:value => v)
+      self.dc_creator = v && RubyXL::StringNode.new(:value => v)
     end
 
     def modifier
@@ -135,7 +135,7 @@ module RubyXL
     end
 
     def modifier=(v)
-      self.cp_last_modified_by = v && RubyXL::StringNodeW3C.new(:value => v)
+      self.cp_last_modified_by = v && RubyXL::StringNode.new(:value => v)
     end
 
     def created_at


### PR DESCRIPTION
Excel shows up a warning when `xsi:type="dcterms:W3CDTF"` is set in docProps/core.xml on `dc:creator` or `cp:lastModifiedBy`.