### PR TITLE
Add support for opening sheets with oleLink nodes

### DIFF
--- a/lib/rubyXL/objects/external_links.rb
+++ b/lib/rubyXL/objects/external_links.rb
@@ -64,6 +64,26 @@ module RubyXL
     define_attribute(:'r:id', :string, :required => true)
     define_element_name 'externalBook'
   end
+  # http://www.datypic.com/sc/ooxml/e-ssml_oleItem-1.html
+  class OleItem < OOXMLObject
+    define_attribute(:name, :string)
+    define_attribute(:icon, :bool)
+    define_attribute(:advise, :bool)
+    define_attribute(:preferPic, :bool)
+    define_element_name 'oleItem'
+  end
+  # http://www.datypic.com/sc/ooxml/e-ssml_oleItems-1.html
+  class OleItems < OOXMLObject
+    define_child_node(RubyXL::OleItem)
+    define_element_name 'oleItems'
+  end
+  # http://www.datypic.com/sc/ooxml/t-ssml_CT_OleLink.html
+  class OleLink < OOXMLObject
+    define_child_node(RubyXL::OleItems)
+    define_attribute(:'r:id', :string, :required => true)
+    define_attribute(:'progId', :string)
+    define_element_name 'oleLink'
+  end
 
   class ExternalLinksFile < OOXMLTopLevelObject
     CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml'
@@ -71,6 +91,7 @@ module RubyXL
 
     include RubyXL::RelationshipSupport
     define_child_node(RubyXL::ExternalBook)
+    define_child_node(RubyXL::OleLink)
 
     define_element_name 'externalLink'
     set_namespaces('http://schemas.openxmlformats.org/spreadsheetml/2006/main' => nil,


### PR DESCRIPTION
I was getting the following error trying to open an XLSX file provided by a end user : 

> Unknown child node [oleLink] for element [externalLink]

So this is adding code to "support" parsing oleLink element. I added code based on documentation and what was already there, but I am no Excel XML expert (DISCLAIMER) and I don't think anyone will actually do anything in ruby with an oleLink reference.

Also, I am not sure it will write the XML correctly after if you try to save the file, but it make the file parsing working so I am happy with my patch for now as I only import data. 