### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/rubyXL.gemspec
+++ b/rubyXL.gemspec
@@ -510,7 +510,7 @@ Gem::Specification.new do |s|
     "test/test_parse_write.rb",
     "tmp/.gitignore"
   ]
-  s.homepage = "http://github.com/gilt/rubyXL".freeze
+  s.homepage = "https://github.com/gilt/rubyXL".freeze
   s.licenses = ["MIT".freeze]
   s.rubygems_version = "3.1.2".freeze
   s.summary = "rubyXL is a gem which allows the parsing, creation, and manipulation of Microsoft Excel (.xlsx/.xlsm) Documents".freeze


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/rubyXL or some tools or APIs that use the gem's metadata.