### PR TITLE
Fix for dates being converted back to a different value.

### DIFF
--- a/lib/rubyXL/objects/workbook.rb
+++ b/lib/rubyXL/objects/workbook.rb
@@ -432,7 +432,9 @@ module RubyXL
         num += 1 unless workbook_properties && workbook_properties.date1904
       end
 
-      num && (base_date + num)
+      days = num.to_i
+      seconds_in_day = ((num - days) * 86400).round(6)
+      num && (base_date + days + (seconds_in_day / 86400))
     end
 
     include Enumerable

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -54,6 +54,18 @@ describe RubyXL::Cell do
 
       # Due to rounding errors, we allow microsecond precision on Time.
       expect(cell.value - tm.to_datetime).to be_within(1.0/86400e6).of(0)
+
+      expected_date = "2020-10-15T14:00:00Z"
+      expected_datetime = Time.parse(expected_date).utc
+      raw_value = "44119.583333333328" # obtained from parsing a xlsx file with the expected date
+      cell = @worksheet.add_cell(r, c, Time.now) # force a date cell type
+      cell.set_number_format('ddd mmm dd, yyyy HH:MM:SS')
+      cell.raw_value = raw_value
+      expect(cell.raw_value).to eq(raw_value), "raw value is not right"
+      cell.set_number_format('ddd mmm dd, yyyy HH:MM:SS')
+
+      # We expect to be exactly the same date
+      expect(cell.value.to_time.utc.iso8601).to eq(expected_datetime.iso8601)
     end
   end
 


### PR DESCRIPTION
We have a file with `2020-10-15 14:00` in a cell, but we obtain `2020-10-15T13:59:59` when we do `cell.value`.

The raw value for the specific date is `"44119.583333333328"` but somehow the conversion to float and adding it to the base date is not good enough to keep the resolution and cames 1 second short for some formats.

