### PR TITLE
Fix insert/delete row column

### DIFF
--- a/lib/rubyXL/convenience_methods/worksheet.rb
+++ b/lib/rubyXL/convenience_methods/worksheet.rb
@@ -107,8 +107,7 @@ module RubyXL
       }
 
       # Update merged cells for all rows below
-      self.merged_cells ||= RubyXL::MergedCells.new
-      merged_cells.each { |mc|
+      merged_cells&.each { |mc|
         next if mc.ref.row_range.last < row_index
 
         in_merged_cell = mc.ref.row_range.first < row_index
@@ -136,9 +135,8 @@ module RubyXL
       }
 
       # Update row number of merged cells
-      self.merged_cells ||= RubyXL::MergedCells.new
-      merged_cells.delete_if { |mc| mc.ref.row_range == (row_index..row_index) }
-      merged_cells.each { |mc|
+      merged_cells&.delete_if { |mc| mc.ref.row_range == (row_index..row_index) }
+      merged_cells&.each { |mc|
         next if mc.ref.row_range.last < row_index
 
         in_merged_cell = mc.ref.row_range.first <= row_index
@@ -149,7 +147,7 @@ module RubyXL
           mc.ref.col_range.last,
         )
       }
-      merged_cells.delete_if { |mc| mc.ref.single_cell? }
+      merged_cells&.delete_if { |mc| mc.ref.single_cell? }
 
       return deleted
     end
@@ -183,8 +181,7 @@ module RubyXL
       cols.insert_column(column_index)
 
       # Update merged cells for all rows below
-      self.merged_cells ||= RubyXL::MergedCells.new
-      merged_cells.each { |mc|
+      merged_cells&.each { |mc|
         next if mc.ref.col_range.last < column_index
 
         in_merged_cell = mc.ref.row_range.first < column_index
@@ -217,9 +214,8 @@ module RubyXL
       cols.each { |range| range.delete_column(column_index) }
 
       # Update row number of merged cells
-      self.merged_cells ||= RubyXL::MergedCells.new
-      merged_cells.delete_if { |mc| mc.ref.col_range == (column_index..column_index) }
-      merged_cells.each { |mc|
+      merged_cells&.delete_if { |mc| mc.ref.col_range == (column_index..column_index) }
+      merged_cells&.each { |mc|
         next if mc.ref.col_range.last < column_index
 
         in_merged_cell = mc.ref.col_range.first <= column_index
@@ -230,7 +226,7 @@ module RubyXL
           mc.ref.col_range.last - 1,
         )
       }
-      merged_cells.delete_if { |mc| mc.ref.single_cell? }
+      merged_cells&.delete_if { |mc| mc.ref.single_cell? }
     end
 
     def get_row_style(row_index)

--- a/spec/lib/worksheet_spec.rb
+++ b/spec/lib/worksheet_spec.rb
@@ -742,6 +742,12 @@ describe RubyXL::Worksheet do
         end
       end
     end
+
+    it 'should not make an empty merged_cells when a worksheet does not have a merged cell' do
+      # If a worksheet has an empty merged_cells, the xlsx has XML error and has to repair.
+      @worksheet.delete_row(0)
+      expect(@worksheet.merged_cells).to be_nil
+    end
   end
 
   describe '.insert_row' do
@@ -843,6 +849,12 @@ describe RubyXL::Worksheet do
         expect(@worksheet.merged_cells.size).to eq 1
         expect(@worksheet.merged_cells.first.ref.to_s).to eq "B2:C3"
       end
+    end
+
+    it 'should not make an empty merged_cells when a worksheet does not have a merged cell' do
+      # If a worksheet has an empty merged_cells, the xlsx has XML error and has to repair.
+      @worksheet.insert_row(0)
+      expect(@worksheet.merged_cells).to be_nil
     end
   end
 
@@ -1002,6 +1014,12 @@ describe RubyXL::Worksheet do
         end
       end
     end
+
+    it 'should not make an empty merged_cells when a worksheet does not have a merged cell' do
+      # If a worksheet has an empty merged_cells, the xlsx has XML error and has to repair.
+      @worksheet.delete_column(0)
+      expect(@worksheet.merged_cells).to be_nil
+    end
   end
 
   describe '.insert_column' do
@@ -1098,6 +1116,12 @@ describe RubyXL::Worksheet do
         expect(@worksheet.merged_cells.size).to eq 1
         expect(@worksheet.merged_cells.first.ref.to_s).to eq "B2:C3"
       end
+    end
+
+    it 'should not make an empty merged_cells when a worksheet does not have a merged cell' do
+      # If a worksheet has an empty merged_cells, the xlsx has XML error and has to repair.
+      @worksheet.insert_column(0)
+      expect(@worksheet.merged_cells).to be_nil
     end
   end
 

--- a/spec/lib/worksheet_spec.rb
+++ b/spec/lib/worksheet_spec.rb
@@ -743,8 +743,8 @@ describe RubyXL::Worksheet do
       end
     end
 
-    it 'should not make an empty merged_cells when a worksheet does not have a merged cell' do
-      # If a worksheet has an empty merged_cells, the xlsx has XML error and has to repair.
+    it 'should not make empty merged_cells when a worksheet does not have a merged cell' do
+      # If a worksheet has empty merged_cells, the xlsx file has an XML error and has to repair.
       @worksheet.delete_row(0)
       expect(@worksheet.merged_cells).to be_nil
     end
@@ -851,8 +851,8 @@ describe RubyXL::Worksheet do
       end
     end
 
-    it 'should not make an empty merged_cells when a worksheet does not have a merged cell' do
-      # If a worksheet has an empty merged_cells, the xlsx has XML error and has to repair.
+    it 'should not make empty merged_cells when a worksheet does not have a merged cell' do
+      # If a worksheet has empty merged_cells, the xlsx file has an XML error and has to repair.
       @worksheet.insert_row(0)
       expect(@worksheet.merged_cells).to be_nil
     end
@@ -1015,8 +1015,8 @@ describe RubyXL::Worksheet do
       end
     end
 
-    it 'should not make an empty merged_cells when a worksheet does not have a merged cell' do
-      # If a worksheet has an empty merged_cells, the xlsx has XML error and has to repair.
+    it 'should not make empty merged_cells when a worksheet does not have a merged cell' do
+      # If a worksheet has empty merged_cells, the xlsx file has an XML error and has to repair.
       @worksheet.delete_column(0)
       expect(@worksheet.merged_cells).to be_nil
     end
@@ -1118,8 +1118,8 @@ describe RubyXL::Worksheet do
       end
     end
 
-    it 'should not make an empty merged_cells when a worksheet does not have a merged cell' do
-      # If a worksheet has an empty merged_cells, the xlsx has XML error and has to repair.
+    it 'should not make empty merged_cells when a worksheet does not have a merged cell' do
+      # If a worksheet has empty merged_cells, the xlsx file has an XML error and has to repair.
       @worksheet.insert_column(0)
       expect(@worksheet.merged_cells).to be_nil
     end


### PR DESCRIPTION
If a worksheet has empty merged_cells, the xlsx file has an XML error and has to repair.

Fixes #393
Ref #390

![Screen Shot 2021-03-30 at 15 35 47](https://user-images.githubusercontent.com/794760/112966995-bba89e80-9185-11eb-91b5-84ba738b7cd2.png)

[sheet1.xml](https://github.com/weshatheleopard/rubyXL/files/6227959/sheet1.xml.txt)
