### PR TITLE
Add convinience methods for set and get workbook title property

### DIFF
--- a/lib/rubyXL/convenience_methods/workbook.rb
+++ b/lib/rubyXL/convenience_methods/workbook.rb
@@ -130,6 +130,14 @@ module RubyXL
       self.defined_names && self.defined_names.find { |n| n.name == name }
     end
 
+    def title
+      self.root.core_properties.dc_title && self.root.core_properties.dc_title.value
+    end
+
+    def title=(v)
+      self.root.core_properties.dc_title = v && RubyXL::StringNode.new(:value => v)
+    end
+
   end
 
   RubyXL::Workbook.send(:include, RubyXL::WorkbookConvenienceMethods) # ruby 2.1 compat

--- a/spec/lib/workbook_spec.rb
+++ b/spec/lib/workbook_spec.rb
@@ -133,6 +133,17 @@ describe RubyXL::Workbook do
     end
   end
 
+  describe '.title' do
+    it 'should contain default title' do
+      expect(@workbook.title).to be_nil
+    end
+
+    it 'should set title properly' do
+      @workbook.title = 'TITLE'
+      expect(@workbook.title).to eq('TITLE')
+    end
+  end
+
   describe '.stream' do
     it "It should not be confused by missing sheet_id" do
       workbook = RubyXL::Workbook.new


### PR DESCRIPTION
As I mentioned here https://github.com/weshatheleopard/rubyXL/issues/395 before, I made a convenience method for the workbook title property.

To see the value: `workbook.title`
To set the value: `workbook.title = 'TITLE'`

Please review my code.

Best,