### PR TITLE
Preserve underline styles and avoid invalid u val

### DIFF
--- a/lib/rubyXL/objects/font.rb
+++ b/lib/rubyXL/objects/font.rb
@@ -1,6 +1,7 @@
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/container_nodes'
 require 'rubyXL/objects/color'
+require 'rubyXL/objects/underline'
 
 module RubyXL
 
@@ -9,21 +10,21 @@ module RubyXL
     # Since we have no capability to load the actual fonts, we'll have to live with the default.
     MAX_DIGIT_WIDTH = 7 # Calibri 11 pt @ 96 dpi
 
-    define_child_node(RubyXL::StringValue,  :node_name => :name)
-    define_child_node(RubyXL::IntegerValue, :node_name => :charset)
-    define_child_node(RubyXL::IntegerValue, :node_name => :family)
-    define_child_node(RubyXL::BooleanValue, :node_name => :b)
-    define_child_node(RubyXL::BooleanValue, :node_name => :i)
-    define_child_node(RubyXL::BooleanValue, :node_name => :strike)
-    define_child_node(RubyXL::BooleanValue, :node_name => :outline)
-    define_child_node(RubyXL::BooleanValue, :node_name => :shadow)
-    define_child_node(RubyXL::BooleanValue, :node_name => :condense)
-    define_child_node(RubyXL::BooleanValue, :node_name => :extend)
+    define_child_node(RubyXL::StringValue,    :node_name => :name)
+    define_child_node(RubyXL::IntegerValue,   :node_name => :charset)
+    define_child_node(RubyXL::IntegerValue,   :node_name => :family)
+    define_child_node(RubyXL::BooleanValue,   :node_name => :b)
+    define_child_node(RubyXL::BooleanValue,   :node_name => :i)
+    define_child_node(RubyXL::BooleanValue,   :node_name => :strike)
+    define_child_node(RubyXL::BooleanValue,   :node_name => :outline)
+    define_child_node(RubyXL::BooleanValue,   :node_name => :shadow)
+    define_child_node(RubyXL::BooleanValue,   :node_name => :condense)
+    define_child_node(RubyXL::BooleanValue,   :node_name => :extend)
     define_child_node(RubyXL::Color)
-    define_child_node(RubyXL::FloatValue,   :node_name => :sz)
-    define_child_node(RubyXL::BooleanValue, :node_name => :u)
-    define_child_node(RubyXL::StringValue,  :node_name => :vertAlign)
-    define_child_node(RubyXL::StringValue,  :node_name => :scheme)
+    define_child_node(RubyXL::FloatValue,     :node_name => :sz)
+    define_child_node(RubyXL::UnderlineValue, :node_name => :u)
+    define_child_node(RubyXL::StringValue,    :node_name => :vertAlign)
+    define_child_node(RubyXL::StringValue,    :node_name => :scheme)
     define_element_name 'font'
 
     def self.default(size = 10)

--- a/lib/rubyXL/objects/underline.rb
+++ b/lib/rubyXL/objects/underline.rb
@@ -1,0 +1,11 @@
+require 'rubyXL/objects/ooxml_object'
+require 'rubyXL/objects/simple_types'
+
+module RubyXL
+  class UnderlineValue < OOXMLObject
+    # According to ST_UnderlineValues in the OOXML schema, a u element in a stylesheet
+    # can have val="single", val="double", val="singleAccounting", val="doubleAccounting",
+    # val="none" or no val attribute at all (same as val="single").
+    define_attribute(:val, :string, :required => false)
+  end
+end

--- a/spec/lib/font_spec.rb
+++ b/spec/lib/font_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe RubyXL::Font do
+  describe '.u' do
+    it 'should preserve all valid values of enum DocumentFormat.OpenXml.Spreadsheet.UnderlineValues' do
+      xml_template = '<font xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><u val="%s"/></font>'
+      expect(RubyXL::Font.parse(xml_template % 'single').u.val).to eq('single')
+      expect(RubyXL::Font.parse(xml_template % 'double').u.val).to eq('double')
+      expect(RubyXL::Font.parse(xml_template % 'singleAccounting').u.val).to eq('singleAccounting')
+      expect(RubyXL::Font.parse(xml_template % 'doubleAccounting').u.val).to eq('doubleAccounting')
+      expect(RubyXL::Font.parse(xml_template % 'none').u.val).to eq('none')
+    end
+
+    it 'should interpret u element without val attribute as single underline' do
+      xml_before = '<font xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><u/></font>'
+      font = RubyXL::Font.parse(xml_before)
+      xml_after = font.write_xml()
+      expect(xml_after).to include('<u/>').or include('<u val="single"/>')
+    end
+
+    it 'should not add underlining automatically' do
+      xml_before = '<font xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"></font>'
+      font = RubyXL::Font.parse(xml_before)
+      xml_after = font.write_xml()
+      expect(xml_after).not_to include('<u')
+    end
+  end
+
+end

--- a/spec/lib/stylesheet_spec.rb
+++ b/spec/lib/stylesheet_spec.rb
@@ -5,17 +5,17 @@ describe RubyXL::NumberFormat do
   describe '.is_date_format?' do
     it 'should return true if number format = dd// yy// mm' do
       expect(RubyXL::NumberFormat.new(:num_fmt_id => 1, :format_code => 'dd// yy// mm').is_date_format?()).to eq(true)
-    end  
+    end
 
     it 'should return true if number format = DD// YY// MM (uppercase)' do
       expect(RubyXL::NumberFormat.new(:num_fmt_id => 1, :format_code => 'DD// YY// MM').is_date_format?()).to eq(true)
-    end  
+    end
 
     it 'should return false if number format = @' do
       expect(RubyXL::NumberFormat.new(:num_fmt_id => 1, :format_code => '@').is_date_format?()).to eq(false)
       expect(RubyXL::NumberFormat.new(:num_fmt_id => 1, :format_code => 'general').is_date_format?()).to eq(false)
       expect(RubyXL::NumberFormat.new(:num_fmt_id => 1, :format_code => '0.00e+00').is_date_format?()).to eq(false)
-    end  
+    end
 
     it 'should properly detect date formats amongst default ones' do
       all_formats = RubyXL::NumberFormats::DEFAULT_NUMBER_FORMATS


### PR DESCRIPTION
Preserve all the following `ST_UnderlineValues` as per OOXML spec:

- `<u/>`
- `<u val="single"/>` = same as `<u/>`
- `<u val="double"/>`
- `<u val="singleAccounting"/>`
- `<u val="doubleAccounting"/>`
- `<u val="none"/>`

Also preserve any invalid `val` value, so this won't fix up spreadsheets with `<u val="1"/>` written by previous versions of RubyXL.

I've also written an RSpec for this change, which passes.

Resolves #405