### PR TITLE
Reduced memory usage. Change of formal arguments.

### DIFF
--- a/lib/rubyXL/objects/ooxml_object.rb
+++ b/lib/rubyXL/objects/ooxml_object.rb
@@ -12,10 +12,10 @@ module RubyXL
     # addressing variable by name creates it in the context of defining class, while calling
     # the setter/getter method addresses it in the context of descendant class,
     # which is what we need.
-    def obtain_class_variable(var_name, default = {})
+    def obtain_class_variable(var_name, default = nil)
       self.class_variable_get(var_name)
     rescue NameError
-      self.class_variable_set(var_name, default)
+      self.class_variable_set(var_name, default || {})
     end
 
     # Defines an attribute of OOXML object.
@@ -219,7 +219,7 @@ module RubyXL
       klass.extend RubyXL::OOXMLObjectClassMethods
     end
 
-    def obtain_class_variable(var_name, default = {})
+    def obtain_class_variable(var_name, default = nil)
       self.class.obtain_class_variable(var_name, default)
     end
     private :obtain_class_variable

--- a/lib/rubyXL/objects/ooxml_object.rb
+++ b/lib/rubyXL/objects/ooxml_object.rb
@@ -224,7 +224,8 @@ module RubyXL
     end
     private :obtain_class_variable
 
-    def initialize(params = {})
+    DEFAULT_HASH = {}
+    def initialize(params = DEFAULT_HASH)
       @local_namespaces = nil
 
       obtain_class_variable(:@@ooxml_attributes).each_value { |v|


### PR DESCRIPTION
I used [memory_profiler](https://github.com/SamSaffron/memory_profiler) to check where rubyXL was using a lot of memory, and fixed it.

I changed the formal arguments to reduce the number of times `{}` is generated.

### Result

- write xlsx
  - https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/operate.rb#L8
- read xlsx
  - https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/operate.rb#L42

#### rubyXL 3.4.20 (with Ruby 3.1.0)

- [write file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/write_base.txt)
  - Total allocated: 16.41 MB (335760 objects)
  - Total retained:  6.58 kB (128 objects)
- [read file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/read_base.txt)
  - Total allocated: 24.26 MB (340069 objects)
  - Total retained:  6.23 kB (57 objects)

#### change `obtain_class_variable`

- [write file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/write_fix_default_hash.txt)
  - Total allocated: 14.37 MB (284724 objects)
  - Total retained:  7.24 kB (129 objects)
- [read file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/read_fix_default_hash.txt)
  - Total allocated: 22.74 MB (301994 objects)
  - Total retained:  6.89 kB (58 objects)

#### change `OOXMLObjectInstanceMethods.initialize`

- [write file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/write_fix_default_hash2.txt)
  - TTotal allocated: 16.08 MB (327529 objects)
  - Total retained:  6.58 kB (128 objects)
- [read file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/read_fix_default_hash2.txt)
  - Total allocated: 23.88 MB (330568 objects)
  - Total retained:  6.23 kB (57 objects)