### PR TITLE
Memoize the key of instance_variable_set

### DIFF
--- a/lib/rubyXL/objects/ooxml_object.rb
+++ b/lib/rubyXL/objects/ooxml_object.rb
@@ -224,11 +224,17 @@ module RubyXL
     end
     private :obtain_class_variable
 
+    @@_variable_keys = {}
     def initialize(params = {})
       @local_namespaces = nil
 
       obtain_class_variable(:@@ooxml_attributes).each_value { |v|
-        instance_variable_set("@#{v[:accessor]}", params[v[:accessor]]) unless v[:computed]
+        unless v[:computed]
+          unless @@_variable_keys[v[:accessor]]
+            @@_variable_keys[v[:accessor]] = "@#{v[:accessor]}".freeze
+          end
+          instance_variable_set(@@_variable_keys[v[:accessor]], params[v[:accessor]])
+        end
       }
 
       init_child_nodes(params)
@@ -243,7 +249,10 @@ module RubyXL
           else nil
           end
 
-        instance_variable_set("@#{v[:accessor]}", initial_value)
+        unless @@_variable_keys[v[:accessor]]
+          @@_variable_keys[v[:accessor]] = "@#{v[:accessor]}".freeze
+        end
+        instance_variable_set(@@_variable_keys[v[:accessor]], initial_value)
       }
     end
     private :init_child_nodes


### PR DESCRIPTION
I used [memory_profiler](https://github.com/SamSaffron/memory_profiler) to check where rubyXL was using a lot of memory, and fixed it.

`"@#{v[:accessor]}"` generates two String objects, which can be expensive depending on the access frequency, so we memoized it.

### Result

- write xlsx
  - https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/operate.rb#L8
- read xlsx
  - https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/operate.rb#L42

### rubyXL 3.4.20 (with Ruby 3.1.0)

- [write file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/write_base.txt)
  - Total allocated: 16.41 MB (335760 objects)
  - Total retained:  6.58 kB (128 objects)
- [read file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/read_base.txt)
  - Total allocated: 24.26 MB (340069 objects)
  - Total retained:  6.23 kB (57 objects)

#### memoize `"@#{v[:accessor]}"`

- [write file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/write_fix_set_string.txt)
  - Total allocated: 14.06 MB (276927 objects)
  - Total retained:  23.97 kB (558 objects)
- [read file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/read_fix_set_string.txt)
  - Total allocated: 21.82 MB (279137 objects)
  - Total retained:  23.62 kB (487 objects)