### PR TITLE
Add `frozen_string_literal: true`

### DIFF
--- a/lib/rubyXL.rb
+++ b/lib/rubyXL.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/root'
 require 'rubyXL/parser'
 

--- a/lib/rubyXL/cell.rb
+++ b/lib/rubyXL/cell.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
 
   module LegacyCell

--- a/lib/rubyXL/convenience_methods.rb
+++ b/lib/rubyXL/convenience_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/convenience_methods/workbook'
 require 'rubyXL/convenience_methods/worksheet'
 require 'rubyXL/convenience_methods/cell'

--- a/lib/rubyXL/convenience_methods/cell.rb
+++ b/lib/rubyXL/convenience_methods/cell.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
   module CellConvenienceMethods
 

--- a/lib/rubyXL/convenience_methods/color.rb
+++ b/lib/rubyXL/convenience_methods/color.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
   module ColorConvenienceMethods
 

--- a/lib/rubyXL/convenience_methods/font.rb
+++ b/lib/rubyXL/convenience_methods/font.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
   module FontConvenienceMethods
     # Funny enough, but presence of <i> without value (equivalent to `val == nul`) means "italic = true"!

--- a/lib/rubyXL/convenience_methods/workbook.rb
+++ b/lib/rubyXL/convenience_methods/workbook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
 
   module WorkbookConvenienceMethods

--- a/lib/rubyXL/convenience_methods/worksheet.rb
+++ b/lib/rubyXL/convenience_methods/worksheet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
 
   module WorksheetConvenienceMethods

--- a/lib/rubyXL/objects/border.rb
+++ b/lib/rubyXL/objects/border.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 

--- a/lib/rubyXL/objects/calculation_chain.rb
+++ b/lib/rubyXL/objects/calculation_chain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/extensions'
 

--- a/lib/rubyXL/objects/cell_style.rb
+++ b/lib/rubyXL/objects/cell_style.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 

--- a/lib/rubyXL/objects/chartsheet.rb
+++ b/lib/rubyXL/objects/chartsheet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 require 'rubyXL/objects/extensions'

--- a/lib/rubyXL/objects/color.rb
+++ b/lib/rubyXL/objects/color.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 

--- a/lib/rubyXL/objects/column_range.rb
+++ b/lib/rubyXL/objects/column_range.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 
 module RubyXL

--- a/lib/rubyXL/objects/comments.rb
+++ b/lib/rubyXL/objects/comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/extensions'
 

--- a/lib/rubyXL/objects/connection.rb
+++ b/lib/rubyXL/objects/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 require 'rubyXL/objects/extensions'

--- a/lib/rubyXL/objects/container_nodes.rb
+++ b/lib/rubyXL/objects/container_nodes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 

--- a/lib/rubyXL/objects/content_types.rb
+++ b/lib/rubyXL/objects/content_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 
 module RubyXL

--- a/lib/rubyXL/objects/data_validation.rb
+++ b/lib/rubyXL/objects/data_validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 require 'rubyXL/objects/formula'

--- a/lib/rubyXL/objects/document_properties.rb
+++ b/lib/rubyXL/objects/document_properties.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/container_nodes'
 require 'time'

--- a/lib/rubyXL/objects/extensions.rb
+++ b/lib/rubyXL/objects/extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 
 module RubyXL

--- a/lib/rubyXL/objects/external_links.rb
+++ b/lib/rubyXL/objects/external_links.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
 
   # http://www.datypic.com/sc/ooxml/e-ssml_sheetName-1.html

--- a/lib/rubyXL/objects/fill.rb
+++ b/lib/rubyXL/objects/fill.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 

--- a/lib/rubyXL/objects/filters.rb
+++ b/lib/rubyXL/objects/filters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 require 'rubyXL/objects/extensions'

--- a/lib/rubyXL/objects/font.rb
+++ b/lib/rubyXL/objects/font.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/container_nodes'
 require 'rubyXL/objects/color'

--- a/lib/rubyXL/objects/formula.rb
+++ b/lib/rubyXL/objects/formula.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 

--- a/lib/rubyXL/objects/ooxml_object.rb
+++ b/lib/rubyXL/objects/ooxml_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 require 'pathname'
 require 'rubyXL/objects/reference'

--- a/lib/rubyXL/objects/query_table.rb
+++ b/lib/rubyXL/objects/query_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 require 'rubyXL/objects/extensions'

--- a/lib/rubyXL/objects/reference.rb
+++ b/lib/rubyXL/objects/reference.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
   class Reference
     ROW_MAX = 1024*1024

--- a/lib/rubyXL/objects/relationships.rb
+++ b/lib/rubyXL/objects/relationships.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'rubyXL/objects/ooxml_object'
 

--- a/lib/rubyXL/objects/root.rb
+++ b/lib/rubyXL/objects/root.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'zip'
 require 'rubyXL/objects/relationships'
 require 'rubyXL/objects/document_properties'

--- a/lib/rubyXL/objects/shared_strings.rb
+++ b/lib/rubyXL/objects/shared_strings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/text'
 require 'rubyXL/objects/extensions'

--- a/lib/rubyXL/objects/sheet_common.rb
+++ b/lib/rubyXL/objects/sheet_common.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/storage'
 

--- a/lib/rubyXL/objects/sheet_data.rb
+++ b/lib/rubyXL/objects/sheet_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 require 'rubyXL/objects/text'
@@ -125,7 +127,7 @@ module RubyXL
     end
 
     def inspect
-      str = "#<#{self.class}(#{row},#{column}): #{raw_value.inspect}"
+      str = +"#<#{self.class}(#{row},#{column}): #{raw_value.inspect}"
       str << " =#{self.formula.expression}" if self.formula
       str << ", datatype=#{self.datatype.inspect}, style_index=#{self.style_index.inspect}>"
       return str

--- a/lib/rubyXL/objects/simple_types.rb
+++ b/lib/rubyXL/objects/simple_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
   ST_PageOrder           = %w{ downThenOver overThenDown }
   ST_Orientation         = %w{ default portrait landscape }

--- a/lib/rubyXL/objects/storage.rb
+++ b/lib/rubyXL/objects/storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
 
   class GenericStorageObject

--- a/lib/rubyXL/objects/stylesheet.rb
+++ b/lib/rubyXL/objects/stylesheet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/cell_style'
 require 'rubyXL/objects/font'

--- a/lib/rubyXL/objects/text.rb
+++ b/lib/rubyXL/objects/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 require 'rubyXL/objects/container_nodes'

--- a/lib/rubyXL/objects/theme.rb
+++ b/lib/rubyXL/objects/theme.rb
@@ -1,4 +1,6 @@
 # encoding: UTF-8  <-- magic comment, need this because of sime fancy fonts in the default scheme below. See http://stackoverflow.com/questions/6444826/ruby-utf-8-file-encoding
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/extensions'
 

--- a/lib/rubyXL/objects/workbook.rb
+++ b/lib/rubyXL/objects/workbook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #require 'tmpdir'
 require 'date'
 require 'rubyXL/objects/ooxml_object'

--- a/lib/rubyXL/objects/worksheet.rb
+++ b/lib/rubyXL/objects/worksheet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubyXL/objects/ooxml_object'
 require 'rubyXL/objects/simple_types'
 require 'rubyXL/objects/extensions'

--- a/lib/rubyXL/parser.rb
+++ b/lib/rubyXL/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
   class Parser
 

--- a/lib/rubyXL/worksheet.rb
+++ b/lib/rubyXL/worksheet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RubyXL
 module LegacyWorksheet
   include Enumerable


### PR DESCRIPTION
I used [memory_profiler](https://github.com/SamSaffron/memory_profiler) to check where rubyXL was using a lot of memory, and fixed it.

Added `frozen_string_literal: true` to `lib/` files.
Testing seems to be fine, but depending on how users use the library, it may have an impact.

### Result

- write xlsx
  - https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/operate.rb#L8
- read xlsx
  - https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/operate.rb#L42

#### rubyXL 3.4.20 (with Ruby 3.1.0)

- [write file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/write_base.txt)
  - Total allocated: 16.41 MB (335760 objects)
  - Total retained:  6.58 kB (128 objects)
- [read file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0/pattern1/read_base.txt)
  - Total allocated: 24.26 MB (340069 objects)
  - Total retained:  6.23 kB (57 objects)

#### frozen_string_literal

- [write file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0_with_frozen/pattern1/write_base.txt)
  - Total allocated: 15.56 MB (314304 objects)
  - Total retained:  6.58 kB (128 objects)
- [read file](https://github.com/ooooooo-q/rubyxl_memory_usage/blob/main/results/ruby_3.1.0_with_frozen/pattern1/read_base.txt)
  - Total allocated: 24.02 MB (334013 objects)
  - Total retained:  6.23 kB (57 objects)
