### PR TITLE
execute date_to_num when the data is Time

### DIFF
--- a/lib/rubyXL/convenience_methods/cell.rb
+++ b/lib/rubyXL/convenience_methods/cell.rb
@@ -9,12 +9,12 @@ module RubyXL
         self.formula = RubyXL::Formula.new(:expression => formula_expression)
       else
         self.datatype = case data
-                        when Date, Numeric then nil
+                        when Date, Time, Numeric then nil
                         else RubyXL::DataType::RAW_STRING
                         end
       end
 
-      data = workbook.date_to_num(data) if data.is_a?(Date)
+      data = workbook.date_to_num(data) if data.is_a?(Date) || data.is_a?(Time)
 
       self.raw_value = data
     end
@@ -140,12 +140,12 @@ module RubyXL
       return nil if xf_obj.alignment.nil?
       xf_obj.alignment.wrap_text
     end
-    
+
     def text_rotation
       validate_worksheet
       xf_obj = get_cell_xf
       return nil if xf_obj.alignment.nil?
-      xf_obj.alignment.text_rotation    
+      xf_obj.alignment.text_rotation
     end
 
     def text_indent()

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -400,6 +400,15 @@ describe RubyXL::Cell do
       expect(@cell.formula).to be_nil
     end
 
+    it 'should cause cell value to match a time that is passed in' do
+      time = Time.parse('January 1, 2011')
+      @cell.change_contents(time)
+      expect(@cell).to receive(:is_date?).at_least(1).and_return(true)
+      expect(@cell.value).to eq(time.to_datetime)
+      expect(@cell.datatype).to be_nil
+      expect(@cell.formula).to be_nil
+    end
+
     it 'should case cell value to match a Float that is passed in' do
       number = 1.25
       @cell.change_contents(number)


### PR DESCRIPTION
This PR is to execute date_to_num when the data is Time.

## before
```
cell = book[0].add_cell(0,0,'')
cell.set_number_format('ddd mmm dd, yyyy HH:MM:SS')
cell.change_contents(Time.new)
cell.datatype
=> "str"
```
at excel
```
2022-02-23 13:42:46 +0900
```

## after
```
...
cell = book[0].add_cell(0,0,'')
cell.set_number_format('ddd mmm dd, yyyy HH:MM:SS')
cell.change_contents(Time.new)
cell.datatype
=> nil
```
at excel
```
Wed Feb 23, 2022 04:38:40
```

