### PR TITLE
Add a `CHANGELOG.md` and describe the last two versions of the gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# v3.4.25 (May 19, 2022)
+
+* Improve code style and consistently (@weshatheleopard)
+* Update `Gemfile.lock`, dependency versions used when developing the gem (@weshatheleopard)
+
+# v3.4.24 (May 16, 2022)
+
+* Add `Cell#add_hyperlink` for adding a hyperlink to a cell (@weshatheleopard)
+* Add `Reference#valid?` for checking if a cell reference is valid (@weshatheleopard)
+* Add `Worksheet#cell_at` for finding a cell by its Excel-style reference (@weshatheleopard)
+* Prevent creation of sheets with reserved names (specifically, `History`) (@weshatheleopard)
+* Update `Gemfile.lock`, dependency versions used when developing the gem (@weshatheleopard)


### PR DESCRIPTION
This PR adds a changelog covering the changes in the two most recent versions of the gem.

It'd be great to have (and keep updated!) a file like this in the repo, as it makes it much easier to work out what's relevant when you're keeping your dependencies up to date. Tools like GitHub's Dependabot automatically show what's in the changelog to make it super easy 🧈 