### PR TITLE
Improve gem homepage URL

### DIFF
--- a/rubyXL.gemspec
+++ b/rubyXL.gemspec
@@ -514,7 +514,7 @@ Gem::Specification.new do |s|
     "test/test_parse_write.rb",
     "tmp/.gitignore"
   ]
-  s.homepage = "http://github.com/gilt/rubyXL".freeze
+  s.homepage = "https://github.com/weshatheleopard/rubyXL".freeze
   s.licenses = ["MIT".freeze]
   s.rubygems_version = "3.3.12".freeze
   s.summary = "rubyXL is a gem which allows the parsing, creation, and manipulation of Microsoft Excel (.xlsx/.xlsm) Documents".freeze


### PR DESCRIPTION
I noticed that http://github.com/gilt/rubyXL redirects to https://github.com/weshatheleopard/rubyXL, so replaced it.

This URL is used at the following part of https://rubygems.org/gems/rubyXL 

![image](https://user-images.githubusercontent.com/111689/175753105-26862309-5ff4-4100-a7a3-9f47b06a3939.png)