### PR TITLE
add support for alternateUrls OOXML

### DIFF
--- a/lib/rubyXL/objects/external_links.rb
+++ b/lib/rubyXL/objects/external_links.rb
@@ -55,11 +55,19 @@ module RubyXL
     define_element_name 'sheetDataSet'
   end
 
+  # https://learn.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/452524b4-b22f-45a9-aac1-81fdd1f1db6c
+  class AlternateUrls < OOXMLObject
+    define_attribute(:absoluteUrl, :string, :required => false)
+    define_attribute(:relativeUrl, :string, :required => false)
+    define_element_name 'xxl21:alternateUrls'
+  end
+
   # http://www.datypic.com/sc/ooxml/e-ssml_externalBook-1.html
   class ExternalBook < OOXMLObject
     define_child_node(RubyXL::SheetNames)
     define_child_node(RubyXL::DefinedNamesExt)
     define_child_node(RubyXL::SheetDataSet)
+    define_child_node(RubyXL::AlternateUrls)
     define_relationship(:required => true)
     define_element_name 'externalBook'
   end
@@ -86,6 +94,7 @@ module RubyXL
     define_attribute(:progId, :string, :required => true)
     define_element_name 'oleLink'
   end
+
 
   class ExternalLinksFile < OOXMLTopLevelObject
     CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml'.freeze


### PR DESCRIPTION
This should fix #435 by adding support for the alternateUrls element ocurring in some newer excel files.

---
The program was tested solely for our own use cases, which might differ from yours.

Florian Pfitzer <florian.pfitzer@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

Licensed under MIT License