### PR TITLE
chore(gemspec): don't include Gemfile.lock

### DIFF
--- a/rubyXL.gemspec
+++ b/rubyXL.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
     ".rubocop.yml",
     "CHANGELOG.md",
     "Gemfile",
-    "Gemfile.lock",
     "LICENSE.txt",
     "README.rdoc",
     "Rakefile",


### PR DESCRIPTION
I was surprised to find dozens of security vulnerability warnings for my application. The offending dependencies were: git, rack, nokogiri, stringio, and rdoc. The offending versions didn't make sense because my application is kept up-to-date and we're running the latest known-security versions of these, and we don't even use the git gem.

Upon closer inspection I realised that these were all coming from `bundle/gems/rubyXL-3.4.22/Gemfile.lock`.

Now, this is a false positive with our vulnerability scanner, but it expects that there's only one `Gemfile.lock` file for an application which is a reasonable assumption.

There's no reason to ship `Gemfile.lock`. Applications won't use it. I don't think there's even a reason to have `Gemfile.lock` committed to the repo here at all, but that's up to you.

Of 237 installed gems, only two include `Gemfile.lock`
```
$ find /usr/local/bundle/ -name Gemfile.lock
/usr/local/bundle/gems/os-1.1.4/Gemfile.lock
/usr/local/bundle/gems/rubyXL-3.4.22/Gemfile.lock
```