### PR TITLE
Prevent `#parse_buffer` from altering input buffer

### DIFF
--- a/lib/rubyXL/parser.rb
+++ b/lib/rubyXL/parser.rb
@@ -15,9 +15,9 @@ module RubyXL
 
     # Parse <tt>.xslx</tt> file contained in a stream (useful for receiving over HTTP).
     def self.parse_buffer(buffer)
-      root = nil # Zip::File.open_buffer somehow fails to return the value from the block :(
       begin
-        ::Zip::File.open_buffer(buffer) { |zip_file| root = RubyXL::WorkbookRoot.parse_zip_file(zip_file) }
+        zip_file = ::Zip::File.open_buffer(buffer)
+        root = RubyXL::WorkbookRoot.parse_zip_file(zip_file)
         root.workbook
       rescue ::Zip::Error => e
         raise e, "XLSX file format error: #{e}", e.backtrace

--- a/spec/lib/parser_spec.rb
+++ b/spec/lib/parser_spec.rb
@@ -101,6 +101,13 @@ describe RubyXL::Parser do
       expect(f).to be_instance_of(RubyXL::Workbook)
     end
 
+    it 'should not modify the buffer state' do
+      buffer = File.read(@file)
+      expect(buffer).to be_instance_of(String)
+      RubyXL::Parser.parse_buffer(buffer)
+      expect(buffer.bytes).to eq(File.read(@file).bytes)
+    end
+
     it 'should parse an IO object correctly' do
       io = File.open(@file)
       expect(io).to be_instance_of(File)


### PR DESCRIPTION
Fixes #453 
This PR prevent `#parse_buffer` from altering input buffer.

As stated in the issue, it is more intuitive for `parse_buffer` to not change the input buffer.
However, the internal call `Zip::File.open_buffer` changes the input buffer if called with block.
Therefore, I changed the calling method so that it does not use block.

