### PR TITLE
Prevent too long cell contents from breaking Excel book

### DIFF
--- a/lib/rubyXL/worksheet.rb
+++ b/lib/rubyXL/worksheet.rb
@@ -1,5 +1,7 @@
 module RubyXL
   module LegacyWorksheet
+    TEXT_LENGTH_LIMIT_IN_CELL = 32767 # 2 ** 15 - 1
+
     include Enumerable
 
     def initialize(params = {})
@@ -50,9 +52,15 @@ module RubyXL
           case data
           when Numeric          then c.raw_value = data
           when String           then
+            if TEXT_LENGTH_LIMIT_IN_CELL < data.length
+              raise ArgumentError, "The maximum length of cell contents (text) is #{TEXT_LENGTH_LIMIT_IN_CELL} characters"
+            end
             c.raw_value = data
             c.datatype = RubyXL::DataType::RAW_STRING
           when RubyXL::RichText then
+            if TEXT_LENGTH_LIMIT_IN_CELL < data.to_s.length
+              raise ArgumentError, "The maximum length of cell contents (text) is #{TEXT_LENGTH_LIMIT_IN_CELL} characters"
+            end
             c.is = data
             c.datatype = RubyXL::DataType::INLINE_STRING
           when Time, Date, DateTime then

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -66,6 +66,30 @@ describe RubyXL::Cell do
       # We expect exactly the same date
       expect(cell.value.to_time.utc.iso8601).to eq(expected_datetime.iso8601)
     end
+
+    it 'should raise against too long String' do
+      ok_data = 'A' * 32767  # The limit is 32767
+
+      expect {
+         @worksheet.add_cell(0,1, ok_data) # 32767 -> OK
+      }.not_to raise_error
+      expect {
+         # 1 longer than the limit, so an exception must be thrown.
+         @worksheet.add_cell(0,2, ok_data + 'B')
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'should raise against too long RichText' do
+      ok_data = 'A' * 32767  # The limit is 32767
+
+      expect {
+         @worksheet.add_cell(0,1, RubyXL::RichText.new(:t => RubyXL::Text.new(:value => ok_data))) # 32767 -> OK
+      }.not_to raise_error
+      expect {
+         # 1 longer than the limit, so an exception must be thrown.
+         @worksheet.add_cell(0,2, RubyXL::RichText.new(:t => RubyXL::Text.new(:value => ok_data + 'B')))
+      }.to raise_error(ArgumentError)
+    end
   end
 
   describe '.change_fill' do


### PR DESCRIPTION
Microsoft Excel has a limit of 32767 characters for cell content.
In the current version of RubyXL, writing content in a cell that exceeds the limit will simply generate a broken book. "broken" means that Excel says it found unreadable content.

Reproducing code:
```
require 'rubyXL'

bad_data = 'A' * 32768
workbook = RubyXL::Workbook.new
workbook[0].add_cell(0,0,bad_data)
workbook.write('broken_book.xlsx') # Broken book for MS Excel will be saved.
```

So I added raising exception to Worksheet#add_cell when it is passed too long contents.
I also wrote a test related to this.

However, how Worksheet#add_cell behaves when too long content is passed may be discussed. For example: instead of throwing an exception, truncate the content beyond the limit and add it to the cell.