### PR TITLE
Bugfix/document properties namespaces

### DIFF
--- a/spec/lib/document_properties_spec.rb
+++ b/spec/lib/document_properties_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'byebug'
+
+describe RubyXL::DocumentPropertiesFile do
+
+  it 'adds default namespaces if not present in original document' do
+    original_xml = <<~EoT
+    <?xml version="1.0" encoding="utf-8"?>
+    <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties">
+      <Application>DevExpress Office File API/24.1.3.0</Application>
+      <AppVersion>24.1</AppVersion>
+    </Properties>
+    EoT
+
+    zip_entry = instance_double(Zip::Entry)
+    allow(zip_entry).to receive(:get_input_stream).and_yield(original_xml)
+
+    zip_file = instance_double(Zip::File, find_entry: zip_entry)
+
+    properties = RubyXL::DocumentPropertiesFile.parse_file(zip_file, Pathname.new("/docProps/app.xml"))
+
+    properties.root = RubyXL::WorkbookRoot.new
+    properties.root.workbook = RubyXL::Workbook.new
+
+    changed_xml = properties.write_xml
+
+    node = Nokogiri::XML(changed_xml)
+    expect(node.namespaces).to eql({
+      "xmlns" => "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties",
+      "xmlns:vt" => "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+    })
+    expect(node.errors).to be_empty
+  end
+
+end


### PR DESCRIPTION
Hello, we have encountered a bug with rubyXL which appears to have been reported already. We have forked the project and created a pull request. If you'd like some changes before merging the pull request, please let us know.

**Fixes Issue #332**

The error reported in #332 was caused by editing a xlsx file with very minimal extended document properties. For example a xlsx file with the following docProps/app.xml:
```
 <?xml version="1.0" encoding="utf-8"?>
    <Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties">
      <Application>DevExpress Office File API/24.1.3.0</Application>
      <AppVersion>24.1</AppVersion>
    </Properties>
```

RubyXL currently adds the worksheet count to the extended document properties, but uses only the namespaces defined in the original file (see lib/rubyXL/objects/ooxml_object.rb:315). This leads to an invalid app.xml, because in the original file the "vt" namspace is not defined.
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties">
  <HeadingPairs>
    <vt:vector baseType="variant" size="2">
      <vt:variant>
        <vt:lpstr>Worksheets</vt:lpstr>
      </vt:variant>
      <vt:variant>
        <vt:i4>1</vt:i4>
      </vt:variant>
    </vt:vector>
  </HeadingPairs>
```

This pull request fixes the issue, so the default namespaces for the document properties object are always set (xmlns && xmlns:vt). Should the document define additional namespaces (or different hrefs for the prefixes) the values of the document are preferred to the default ones (like before).

**Related to Issue #446**

This error is just a re-report. So this pull request should fix the underlying cause as well. But the attached xlsx file (rubyxl_issue_332_example.xlsx) is already corrupted (meaning the "vt" namespace is missing), and because of this still causes an error:

```
lib/rubyXL/objects/ooxml_object.rb:152:in `block in parse': undefined method `href' for nil:NilClass (NoMethodError)
```

Maybe this could be fixed, but considering Excel shows an alert when opening the file, it might be better to just keep the error, so it does not go unnoticed.