### PR TITLE
#obtain_class_variable: fix NameError warnings if $DEBUG

### DIFF
--- a/lib/rubyXL/objects/ooxml_object.rb
+++ b/lib/rubyXL/objects/ooxml_object.rb
@@ -13,9 +13,11 @@ module RubyXL
     # the setter/getter method addresses it in the context of descendant class,
     # which is what we need.
     def obtain_class_variable(var_name, default = nil)
-      self.class_variable_get(var_name)
-    rescue NameError
-      self.class_variable_set(var_name, default || {})
+      if self.class_variable_defined? var_name
+        self.class_variable_get(var_name)
+      else
+        self.class_variable_set(var_name, default || {})
+      end
     end
 
     # Defines an attribute of OOXML object.


### PR DESCRIPTION
This avoids the `NameError` exceptions used for control flow and instead just checks whether the class variable exists first.