### PR TITLE
`change_border_color` modifies the border color of other cells.

### DIFF
--- a/lib/rubyXL/convenience_methods/workbook.rb
+++ b/lib/rubyXL/convenience_methods/workbook.rb
@@ -92,6 +92,10 @@ module RubyXL
     def modify_border_color(style_index, direction, color)
       xf = cell_xfs[style_index || 0].dup
       new_border = borders[xf.border_id || 0].dup
+
+      edge = new_border.send(direction)
+      new_border.send("#{direction}=", edge.dup) if edge
+
       new_border.set_edge_color(direction, color)
 
       xf.border_id = borders.find_index { |x| x == new_border } # Reuse existing border, if it exists

--- a/spec/lib/cell_spec.rb
+++ b/spec/lib/cell_spec.rb
@@ -263,6 +263,16 @@ describe RubyXL::Cell do
       expect(@cell.get_border_color(:top)).to eq('FF0000')
       expect(@cell.get_border(:top)).to eq('thin')
     end
+
+    it 'should not change the border color of another cell with the same style' do
+      another_cell = @worksheet[0][1]
+      @cell.change_border(:right, 'medium')
+      another_cell.change_border(:right, 'medium')
+      @cell.change_border_color(:right, 'FF0000')
+      another_cell.change_border_color(:right, '008000')
+      expect(@cell.get_border_color(:right)).to eq('FF0000')
+      expect(another_cell.get_border_color(:right)).to eq('008000')
+    end
   end
 
   describe '.change_border' do


### PR DESCRIPTION
First of all, thank you for creating this awesome gem !

I encountered a case where change_border_color changes the border color of other cells with the same style.

Steps to reproduce are

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rubyXL", github: 'weshatheleopard/rubyXL', branch: 'master'

  gem 'minitest'
end

require 'rubyXL'
require 'rubyXL/convenience_methods'
require 'minitest/autorun'

class ChangeBorderTest < Minitest::Test
  def setup
    workbook = RubyXL::Workbook.new
    worksheet = workbook[0]

    worksheet.add_cell(0, 0)
    worksheet.add_cell(0, 1)

    @cell = worksheet[0][0]
    @another_cell = worksheet[0][1]

    # apply same style
    @cell.change_border(:right, 'thick')
    @another_cell.change_border(:right, 'thick')

    # apply different colors to each cell
    @cell.change_border_color(:right, '0ba53d') # green
    @another_cell.change_border_color(:right, 'ff0000') #red
  end

  def test_cell_color_is_green
    assert_equal '0ba53d', @cell.get_border_color(:right)
  end

  def test_another_cell_color_is_red
    assert_equal 'ff0000', @another_cell.get_border_color(:right)
  end
end
```

Test results are

```
Fetching https://github.com/weshatheleopard/rubyXL.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Run options: --seed 58174

# Running:

.F

Finished in 0.010361s, 193.0316 runs/s, 193.0316 assertions/s.

  1) Failure:
ChangeBorderTest#test_cell_color_is_green [rubyXL_change_border_color_test.rb:39]:
Expected: "0ba53d"
  Actual: "ff0000"

2 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

I expected `@cell`'s right border color to be green(#0ba53d'), but it was actually red(#ff0000).


The root cause of this issue is that `modify_border_color`, which is called by `change_border_color`, shallow copies the Border object and the shallow copy modifies the original BorderEdge object. Just like the `modify_border` method above it, when the Border object already has a BorderEdge object, the BorderEdge object needs to be shallow copied ( or deep copies the Border object).

https://github.com/weshatheleopard/rubyXL/blob/c44254f5d9b124650741877a7901f5052fbe9f6c/lib/rubyXL/convenience_methods/workbook.rb#L92-L103

