### PR TITLE
Handle hyperlinks better

### DIFF
--- a/lib/rubyXL/convenience_methods/cell.rb
+++ b/lib/rubyXL/convenience_methods/cell.rb
@@ -1,5 +1,7 @@
 module RubyXL
   module CellConvenienceMethods
+    EXCEL_HYPERLINK_LIMIT_PER_WORKSHEET = 65_530 # Excel has a hard limit of 65,530 hyperlinks per Worksheet. HYPERLINK formulas are not included in this limit.
+
     def change_contents(data, formula_expression = nil)
       validate_worksheet
 
@@ -263,6 +265,15 @@ module RubyXL
       hyperlink = RubyXL::Hyperlink.new(:ref => self.r, :r_id => r_id)
       hyperlink.tooltip = tooltip if tooltip
       worksheet.hyperlinks ||= RubyXL::Hyperlinks.new
+
+      if worksheet.hyperlinks.size >= EXCEL_HYPERLINK_LIMIT_PER_WORKSHEET # Do not create hyperlinks once the Excel limit of 65,530 is reached. Return false.
+        unless @excel_hyperlink_limit_per_worksheet_warned
+          Rails.logger.warn("Excel hyperlink limit (65,530) reached in worksheet '#{worksheet.sheet_name}' at row #{row}, column #{column}. Further hyperlinks skipped.")
+          @excel_hyperlink_limit_per_worksheet_warned = true
+        end
+        return false
+      end
+
       worksheet.hyperlinks << hyperlink
     end
 

--- a/lib/rubyXL/worksheet.rb
+++ b/lib/rubyXL/worksheet.rb
@@ -57,6 +57,9 @@ module RubyXL
             end
             c.raw_value = data
             c.datatype = RubyXL::DataType::RAW_STRING
+            if data.match?( URI::DEFAULT_PARSER.make_regexp ) # If content is a URL then use the HYPERLINK formula to make it clickable.
+              c.formula = RubyXL::Formula.new(:expression => %(HYPERLINK("#{ data }")))
+            end
           when RubyXL::RichText then
             if data.to_s.length > TEXT_LENGTH_LIMIT_IN_CELL
               raise ArgumentError, "The maximum length of cell contents (text) is #{TEXT_LENGTH_LIMIT_IN_CELL} characters"


### PR DESCRIPTION
## Prevent adding more hyperlinks than the allowed limit per worksheet in Excel of 65,530.

Exceeding this limit will result in an error when opening up the file, similar to this:

> We found a problem with some content in ‘.xlsx'. Do you want us to try to recover as much as we can? If you trust the source of this workbook, click Yes.

<img width="281" height="306" alt="Screen Shot 2026-03-04 at 09 33 21" src="https://github.com/user-attachments/assets/27575584-cf76-4ae9-a647-2a898d981fe4" />

With this change we now prevent the creation of hyperlinks if the limit of 65,530 has been reached.

We will also output a warning to the Rails log but only once. It will show the worksheet name as well as the row and column where it was exceeded.

Fixes https://github.com/weshatheleopard/rubyXL/issues/475

## If the contents of a cell is a URL and does not include a formula, use the `HYPERLINK` formula to make it clickable.

This also gets around the 65,530 hyperlinks per Worksheet limit in Excel as these `HYPERLINK` formulas do not contribute to that count.

Related to https://github.com/weshatheleopard/rubyXL/issues/475.