### PR TITLE
Run CI on all supported Ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,15 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
+
 jobs:
   build:
+    parameters:
+      ruby-version:
+        type: string
     docker:
-      # specify the version you desire here
-      - image: cimg/ruby:3.1.4
+      - image: cimg/ruby:<< parameters.ruby-version >>
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -58,3 +61,11 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+
+workflows:
+  test:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              ruby-version: ["3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]


### PR DESCRIPTION
Update CI to run tests on the required Ruby versions to ensure the project works correctly across each version.

`rubyXL` does not explicitly state supported Ruby versions, but its dependency `rubyzip >= 3.2.2` requires Ruby 3.0 or higher ( https://rubygems.org/gems/rubyzip/versions/3.2.2 ), so target Ruby 3.0 and above.
